### PR TITLE
Add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,20 @@
+{
+    "name": "php/ext-task",
+    "homepage": "https://github.com/concurrent-php/task",
+    "description": "Stubs for the ext-task extension.",
+    "keywords": [
+        "async",
+        "asynchronous",
+        "concurrency",
+        "promise",
+        "awaitable",
+        "future"
+    ],
+    "license": "PHP-3.01",
+    "require": {
+        "php": ">=7.2"
+    },
+    "support": {
+        "issues": "https://github.com/concurrent-php/task/issues"
+    }
+}


### PR DESCRIPTION
This allows installing the stubs easier with Composer for auto-complete.

I'm not sure about the package name, I like using `php` as vendor here. I'd also be happy to adopt the extension to @amphp and using `ext-async` as package name. The naming (if changed) should probably be changed before adding the package to Packagist.