### PR TITLE
Improved Event Loop Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ mkinstalldirs
 run-*
 
 tests/*
+!tests/*.inc
 !tests/*.phpt
 
 composer.lock

--- a/README.md
+++ b/README.md
@@ -91,14 +91,14 @@ class TaskScheduler implements \Countable
 }
 ```
 
-### TaskLoopScheduler
+### LoopTaskScheduler
 
-You can extend the `TaskLoopScheduler` class to create a scheduler with support for an event loop. The scheduler provides integration by letting you override the `runLoop()` method that must start the event loop and keep it running until no more events can occur. The primary problem with event loop integration is that you need to call `dispatch()` whenever tasks are ready run. You can override the `activate()` method to schedule execution of the `dispatch()` with your event loop (future tick or defer watcher). The scheduler will call `activate` whenever a task is registered for execution and the scheduler is not in the process of dispatching tasks.
+You can extend the `LoopTaskScheduler` class to create a scheduler with support for an event loop. The scheduler provides integration by letting you override the `runLoop()` method that must start the event loop and keep it running until no more events can occur. The primary problem with event loop integration is that you need to call `dispatch()` whenever tasks are ready run. You can override the `activate()` method to schedule execution of the `dispatch()` with your event loop (future tick or defer watcher). The scheduler will call `activate` whenever a task is registered for execution and the scheduler is not in the process of dispatching tasks.
 
 ```php
 namespace Concurrent;
 
-abstract class TaskLoopScheduler extends TaskScheduler
+abstract class LoopTaskScheduler extends TaskScheduler
 {   
     protected function activate(): void { }
     

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ class TaskScheduler implements \Countable
 
 ### LoopTaskScheduler
 
-You can extend the `LoopTaskScheduler` class to create a scheduler with support for an event loop. The scheduler provides integration by letting you override the `runLoop()` method that must start the event loop and keep it running until no more events can occur. The primary problem with event loop integration is that you need to call `dispatch()` whenever tasks are ready run. You can override the `activate()` method to schedule execution of the `dispatch()` with your event loop (future tick or defer watcher). The scheduler will call `activate` whenever a task is registered for execution and the scheduler is not in the process of dispatching tasks.
+You can extend the `LoopTaskScheduler` class to create a scheduler with support for an event loop. The scheduler provides integration by letting you implement the `runLoop()` method that must start the event loop and keep it running until no more events can occur. The primary problem with event loop integration is that you need to call `dispatch()` whenever tasks are ready run. You have to implement the `activate()` method to schedule execution of `dispatch()` with your event loop (future tick or defer watcher). The scheduler will call `activate()` whenever a task is registered for execution and the scheduler is not in the process of dispatching tasks. It is also necessary to implement `stopLoop()` that is needed if `await()` is used from the main execution (the event loop always runs in the context of the main execution). A call to `stopLoop()` should stop the event loop after current tick has completed (you can keep executing for a few ticks as well, but this decreases responsiveness of the main execution).
 
 ```php
 namespace Concurrent;
@@ -103,6 +103,8 @@ abstract class LoopTaskScheduler extends TaskScheduler
     protected function activate(): void { }
     
     protected function runLoop(): void { }
+    
+    protected function stopLoop(): void { }
 }
 ```
 

--- a/examples/b.php
+++ b/examples/b.php
@@ -37,12 +37,6 @@ TaskScheduler::setDefaultScheduler(new class($loop) extends TaskLoopScheduler {
         $this->loop->run();
         var_dump('END LOOP');
     }
-
-    protected function stopLoop()
-    {
-        var_dump('STOP LOOP');
-        $this->loop->stop();
-    }
 });
 
 function adapt(\React\Promise\PromiseInterface $promise): Awaitable

--- a/examples/b.php
+++ b/examples/b.php
@@ -37,6 +37,12 @@ TaskScheduler::setDefaultScheduler(new class($loop) extends LoopTaskScheduler {
         $this->loop->run();
         var_dump('END LOOP');
     }
+    
+    protected function stopLoop()
+    {
+        var_dump('STOP LOOP');
+        $this->loop->stop();
+    }
 });
 
 function adapt(\React\Promise\PromiseInterface $promise): Awaitable

--- a/examples/b.php
+++ b/examples/b.php
@@ -12,7 +12,7 @@ register_shutdown_function(function () {
     echo "===> Shutdown function(s) execute here.\n";
 });
 
-TaskScheduler::setDefaultScheduler(new class($loop) extends TaskScheduler {
+TaskScheduler::setDefaultScheduler(new class($loop) extends TaskLoopScheduler {
 
     protected $loop;
 

--- a/examples/b.php
+++ b/examples/b.php
@@ -12,7 +12,7 @@ register_shutdown_function(function () {
     echo "===> Shutdown function(s) execute here.\n";
 });
 
-TaskScheduler::setDefaultScheduler(new class($loop) extends TaskLoopScheduler {
+TaskScheduler::setDefaultScheduler(new class($loop) extends LoopTaskScheduler {
 
     protected $loop;
 

--- a/examples/b.php
+++ b/examples/b.php
@@ -67,7 +67,7 @@ Task::await(Task::async(function () use ($loop, $work) {
     Task::async(function () use ($loop) {
         $defer = new Deferred();
         
-        $loop->addTimer(.8, function () use ($defer) {
+        $loop->addTimer(1, function () use ($defer) {
             $defer->resolve('H :)');
         });
         
@@ -78,7 +78,7 @@ Task::await(Task::async(function () use ($loop, $work) {
         var_dump(Task::await(adapt($defer->promise())));
     });
     
-    $loop->addTimer(.05, function () use ($work, $defer) {
+    $loop->addTimer(.5, function () use ($work, $defer) {
         $defer->resolve('F');
         
         Task::async($work, 'G');

--- a/include/awaitable.h
+++ b/include/awaitable.h
@@ -38,7 +38,6 @@ struct _async_awaitable_cb {
 
 void async_awaitable_register_continuation(async_awaitable_cb **cont, void *obj, zval *data, async_awaitable_func func);
 void async_awaitable_trigger_continuation(async_awaitable_cb **cont, zval *result, zend_bool success);
-void async_awaitable_dispose_continuation(async_awaitable_cb **cont);
 
 void async_awaitable_ce_register();
 

--- a/include/awaitable.h
+++ b/include/awaitable.h
@@ -32,11 +32,12 @@ typedef void (*async_awaitable_func)(void *obj, zval *data, zval *result, zend_b
 struct _async_awaitable_cb {
 	void *object;
 	zval data;
+	zend_bool disposed;
 	async_awaitable_func func;
 	async_awaitable_cb *next;
 };
 
-void async_awaitable_register_continuation(async_awaitable_cb **cont, void *obj, zval *data, async_awaitable_func func);
+async_awaitable_cb *async_awaitable_register_continuation(async_awaitable_cb **cont, void *obj, zval *data, async_awaitable_func func);
 void async_awaitable_trigger_continuation(async_awaitable_cb **cont, zval *result, zend_bool success);
 
 void async_awaitable_ce_register();

--- a/include/fiber.h
+++ b/include/fiber.h
@@ -48,6 +48,8 @@ struct _async_fiber {
 	/* Status of the fiber, one of the ASYNC_FIBER_STATUS_* constants. */
 	zend_uchar status;
 
+	zend_bool disposed;
+
 	/* Callback and info / cache to be used when fiber is started. */
 	zend_fcall_info fci;
 	zend_fcall_info_cache fcc;

--- a/include/fiber.h
+++ b/include/fiber.h
@@ -33,6 +33,9 @@ void async_fiber_shutdown();
 typedef void* async_fiber_context;
 typedef struct _async_fiber async_fiber;
 
+typedef void (* async_fiber_func)();
+typedef void (* async_fiber_run_func)(async_fiber *fiber);
+
 struct _async_fiber {
 	/* Fiber PHP object handle. */
 	zend_object std;
@@ -49,6 +52,8 @@ struct _async_fiber {
 
 	/* Native fiber context of this fiber, will be created during call to start(). */
 	async_fiber_context context;
+
+	async_fiber_run_func func;
 
 	/* Destination for a PHP value being passed into or returned from the fiber. */
 	zval *value;
@@ -71,8 +76,6 @@ extern const zend_uchar ASYNC_FIBER_STATUS_RUNNING;
 extern const zend_uchar ASYNC_FIBER_STATUS_FINISHED;
 extern const zend_uchar ASYNC_FIBER_STATUS_DEAD;
 
-typedef void (* async_fiber_func)();
-
 void async_fiber_run();
 zend_bool async_fiber_switch_to(async_fiber *fiber);
 
@@ -83,6 +86,8 @@ async_fiber_context async_fiber_create_context();
 
 zend_bool async_fiber_create(async_fiber_context context, async_fiber_func func, size_t stack_size);
 void async_fiber_destroy(async_fiber_context context);
+
+zend_object *async_fiber_object_create(zend_class_entry *ce);
 
 zend_bool async_fiber_switch_context(async_fiber_context current, async_fiber_context next);
 zend_bool async_fiber_yield(async_fiber_context current);

--- a/include/fiber.h
+++ b/include/fiber.h
@@ -40,6 +40,8 @@ struct _async_fiber {
 	/* Fiber PHP object handle. */
 	zend_object std;
 
+	zend_string *id;
+
 	/* Implementation-specific fiber type. */
 	zend_uchar type;
 

--- a/include/task.h
+++ b/include/task.h
@@ -76,18 +76,6 @@ void async_task_ce_register();
 
 END_EXTERN_C()
 
-#define ASYNC_TASK_DELEGATE_RESULT(status, result) do { \
-	if (status == ASYNC_OP_RESOLVED) { \
-		RETURN_ZVAL(result, 1, 0); \
-	} else if (status == ASYNC_OP_FAILED) { \
-		Z_ADDREF_P(result); \
-		execute_data->opline--; \
-		zend_throw_exception_internal(result); \
-		execute_data->opline++; \
-		return; \
-	} \
-} while (0)
-
 #endif
 
 /*

--- a/include/task.h
+++ b/include/task.h
@@ -39,9 +39,6 @@ struct _async_task {
 	/* Task scheduler being used to execute the task. */
 	async_task_scheduler *scheduler;
 
-	/* Unique identifier of this task. */
-	size_t id;
-
 	/* Async execution context provided to the task. */
 	async_context *context;
 
@@ -57,6 +54,9 @@ struct _async_task {
 	/* Return value of the task, may also be an error object, check status for outcome. */
 	zval result;
 
+	/* Current suspension point of the task. */
+	async_awaitable_cb *suspended;
+
 	/* Linked list of registered continuation callbacks. */
 	async_awaitable_cb *continuation;
 };
@@ -67,6 +67,7 @@ extern const zend_uchar ASYNC_TASK_OPERATION_NONE;
 extern const zend_uchar ASYNC_TASK_OPERATION_START;
 extern const zend_uchar ASYNC_TASK_OPERATION_RESUME;
 
+void async_task_dispose(async_task *task);
 async_task *async_task_object_create();
 
 void async_task_start(async_task *task);

--- a/include/task.h
+++ b/include/task.h
@@ -76,10 +76,17 @@ void async_task_ce_register();
 
 END_EXTERN_C()
 
-typedef struct _async_task_stop_info {
-	async_task_scheduler *scheduler;
-	zend_bool required;
-} async_task_stop_info;
+#define ASYNC_TASK_DELEGATE_RESULT(status, result) do { \
+	if (status == ASYNC_OP_RESOLVED) { \
+		RETURN_ZVAL(result, 1, 0); \
+	} else if (status == ASYNC_OP_FAILED) { \
+		Z_ADDREF_P(result); \
+		execute_data->opline--; \
+		zend_throw_exception_internal(result); \
+		execute_data->opline++; \
+		return; \
+	} \
+} while (0)
 
 #endif
 

--- a/include/task.h
+++ b/include/task.h
@@ -21,9 +21,9 @@
 
 #include "php.h"
 #include "awaitable.h"
+#include "context.h"
+#include "fiber.h"
 
-typedef void* async_fiber_context;
-typedef struct _async_context async_context;
 typedef struct _async_task_scheduler async_task_scheduler;
 
 BEGIN_EXTERN_C()

--- a/include/task_scheduler.h
+++ b/include/task_scheduler.h
@@ -12,7 +12,7 @@
   | obtain it through the world-wide-web, please send a note to          |
   | license@php.net so we can mail you a copy immediately.               |
   +----------------------------------------------------------------------+
-  | Authors: Martin Schröder <m.schroeder2007@gmail.com>                 |
+  | Authors: Martin SchrÃ¶der <m.schroeder2007@gmail.com>                 |
   +----------------------------------------------------------------------+
 */
 
@@ -20,13 +20,15 @@
 #define ASYNC_TASK_SCHEDULER_H
 
 #include "php.h"
+#include "context.h"
+#include "fiber.h"
 
 typedef struct _async_task async_task;
-typedef struct _async_context async_context;
 
 BEGIN_EXTERN_C()
 
 extern zend_class_entry *async_task_scheduler_ce;
+extern zend_class_entry *async_task_loop_scheduler_ce;
 
 typedef struct _async_task_scheduler async_task_scheduler;
 
@@ -43,6 +45,10 @@ struct _async_task_scheduler {
 	/* Points to the last task to be run (needed to insert tasks into the run queue. */
 	async_task *last;
 
+	zend_bool loop;
+	zend_bool stop_loop;
+	async_fiber *fiber;
+
 	zend_bool running;
 	zend_bool dispatching;
 	zend_bool activate;
@@ -53,7 +59,6 @@ async_task_scheduler *async_task_scheduler_get();
 zend_bool async_task_scheduler_enqueue(async_task *task);
 
 void async_task_scheduler_run_loop(async_task_scheduler *scheduler);
-void async_task_scheduler_stop_loop(async_task_scheduler *scheduler);
 
 void async_task_scheduler_ce_register();
 void async_task_scheduler_ce_unregister();

--- a/include/task_scheduler.h
+++ b/include/task_scheduler.h
@@ -21,7 +21,6 @@
 
 #include "php.h"
 #include "context.h"
-#include "fiber.h"
 
 typedef struct _async_task async_task;
 
@@ -46,8 +45,6 @@ struct _async_task_scheduler {
 	async_task *last;
 
 	zend_bool loop;
-	zend_bool stop_loop;
-	async_fiber *fiber;
 
 	zend_bool running;
 	zend_bool dispatching;
@@ -60,6 +57,7 @@ async_task_scheduler *async_task_scheduler_get();
 
 zend_bool async_task_scheduler_enqueue(async_task *task);
 void async_task_scheduler_run_loop(async_task_scheduler *scheduler);
+void concurrent_task_scheduler_stop_loop(async_task_scheduler *scheduler);
 
 void async_task_scheduler_ce_register();
 void async_task_scheduler_ce_unregister();

--- a/include/task_scheduler.h
+++ b/include/task_scheduler.h
@@ -12,7 +12,7 @@
   | obtain it through the world-wide-web, please send a note to          |
   | license@php.net so we can mail you a copy immediately.               |
   +----------------------------------------------------------------------+
-  | Authors: Martin SchrÃ¶der <m.schroeder2007@gmail.com>                 |
+  | Authors: Martin Schröder <m.schroeder2007@gmail.com>                 |
   +----------------------------------------------------------------------+
 */
 

--- a/include/task_scheduler.h
+++ b/include/task_scheduler.h
@@ -52,12 +52,13 @@ struct _async_task_scheduler {
 	zend_bool running;
 	zend_bool dispatching;
 	zend_bool activate;
+
+	HashTable *tasks;
 };
 
 async_task_scheduler *async_task_scheduler_get();
 
 zend_bool async_task_scheduler_enqueue(async_task *task);
-
 void async_task_scheduler_run_loop(async_task_scheduler *scheduler);
 
 void async_task_scheduler_ce_register();

--- a/lib/AsyncTestCase.php
+++ b/lib/AsyncTestCase.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ +----------------------------------------------------------------------+
+ | PHP Version 7                                                        |
+ +----------------------------------------------------------------------+
+ | Copyright (c) 1997-2018 The PHP Group                                |
+ +----------------------------------------------------------------------+
+ | This source file is subject to version 3.01 of the PHP license,      |
+ | that is bundled with this package in the file LICENSE, and is        |
+ | available through the world-wide-web at the following url:           |
+ | http://www.php.net/license/3_01.txt                                  |
+ | If you did not receive a copy of the PHP license and are unable to   |
+ | obtain it through the world-wide-web, please send a note to          |
+ | license@php.net so we can mail you a copy immediately.               |
+ +----------------------------------------------------------------------+
+ | Authors: Martin Schröder <m.schroeder2007@gmail.com>                 |
+ +----------------------------------------------------------------------+
+ */
+
+namespace Concurrent;
+
+use PHPUnit\Framework\TestCase;
+
+abstract class AsyncTestCase extends TestCase
+{
+    protected function createTaskScheduler(): TaskScheduler
+    {
+        return new TaskScheduler();
+    }
+
+    protected function runTest()
+    {
+        return $this->createTaskScheduler()->run(function () {
+            return parent::runTest();
+        });
+    }
+}

--- a/lib/stubs.php
+++ b/lib/stubs.php
@@ -80,7 +80,7 @@ class TaskScheduler implements \Countable
     public static final function setDefaultScheduler(TaskScheduler $scheduler): void { }
 }
 
-abstract class TaskLoopScheduler extends TaskScheduler
+abstract class LoopTaskScheduler extends TaskScheduler
 {   
     protected function activate(): void { }
     

--- a/lib/stubs.php
+++ b/lib/stubs.php
@@ -77,13 +77,14 @@ class TaskScheduler implements \Countable
     
     protected final function dispatch(): void { }
     
+    public static final function setDefaultScheduler(TaskScheduler $scheduler): void { }
+}
+
+abstract class TaskLoopScheduler extends TaskScheduler
+{   
     protected function activate(): void { }
     
     protected function runLoop(): void { }
-    
-    protected function stopLoop(): void { }
-    
-    public static final function setDefaultScheduler(TaskScheduler $scheduler): void { }
 }
 
 final class Fiber

--- a/lib/stubs.php
+++ b/lib/stubs.php
@@ -85,6 +85,8 @@ abstract class LoopTaskScheduler extends TaskScheduler
     protected function activate(): void { }
     
     protected function runLoop(): void { }
+    
+    protected function stopLoop(): void { }
 }
 
 final class Fiber

--- a/php_async.h
+++ b/php_async.h
@@ -71,8 +71,6 @@ ZEND_BEGIN_MODULE_GLOBALS(async)
 	/* Error to be thrown into a fiber (will be populated by throw()). */
 	zval *error;
 
-	size_t counter;
-
 ZEND_END_MODULE_GLOBALS(async)
 
 ASYNC_API ZEND_EXTERN_MODULE_GLOBALS(async)

--- a/php_async.h
+++ b/php_async.h
@@ -82,6 +82,12 @@ ASYNC_API ZEND_EXTERN_MODULE_GLOBALS(async)
 ZEND_TSRMLS_CACHE_EXTERN()
 #endif
 
+#define ASYNC_CHECK_FATAL(expr, message) do { \
+	if (UNEXPECTED(expr)) { \
+		zend_error_noreturn(E_CORE_ERROR, message); \
+	} \
+} while (0)
+
 #define ASYNC_CHECK_ERROR(expr, message) do { \
     if (UNEXPECTED(expr)) { \
     	zend_throw_error(NULL, message); \

--- a/php_async.h
+++ b/php_async.h
@@ -43,6 +43,8 @@ extern zend_module_entry async_module_entry;
 #include "TSRM.h"
 #endif
 
+#define ASYNC_OP_RESOLVED 64
+#define ASYNC_OP_FAILED 65
 
 ZEND_BEGIN_MODULE_GLOBALS(async)
 	/* Root fiber context (main thread). */

--- a/src/awaitable.c
+++ b/src/awaitable.c
@@ -50,6 +50,7 @@ void async_awaitable_trigger_continuation(async_awaitable_cb **cont, zval *resul
 	async_awaitable_cb *next;
 
 	current = *cont;
+	*cont = NULL;
 
 	if (current != NULL) {
 		do {
@@ -65,33 +66,6 @@ void async_awaitable_trigger_continuation(async_awaitable_cb **cont, zval *resul
 			current = next;
 		} while (current != NULL);
 	}
-
-	*cont = NULL;
-}
-
-void async_awaitable_dispose_continuation(async_awaitable_cb **cont)
-{
-	async_awaitable_cb *current;
-	async_awaitable_cb *next;
-
-	current = *cont;
-
-	if (current != NULL) {
-		do {
-			next = current->next;
-			*cont = next;
-
-			current->func(current->object, &current->data, NULL, 0);
-
-			zval_ptr_dtor(&current->data);
-
-			efree(current);
-
-			current = next;
-		} while (current != NULL);
-	}
-
-	*cont = NULL;
 }
 
 static int async_awaitable_implement_interface(zend_class_entry *interface, zend_class_entry *implementor)

--- a/src/deferred.c
+++ b/src/deferred.c
@@ -28,8 +28,8 @@ zend_class_entry *async_deferred_ce;
 zend_class_entry *async_deferred_awaitable_ce;
 
 const zend_uchar ASYNC_DEFERRED_STATUS_PENDING = 0;
-const zend_uchar ASYNC_DEFERRED_STATUS_RESOLVED = 1;
-const zend_uchar ASYNC_DEFERRED_STATUS_FAILED = 2;
+const zend_uchar ASYNC_DEFERRED_STATUS_RESOLVED = ASYNC_OP_RESOLVED;
+const zend_uchar ASYNC_DEFERRED_STATUS_FAILED = ASYNC_OP_FAILED;
 
 static zend_object_handlers async_deferred_handlers;
 static zend_object_handlers async_deferred_awaitable_handlers;

--- a/src/deferred.c
+++ b/src/deferred.c
@@ -105,7 +105,7 @@ static void async_deferred_object_destroy(zend_object *object)
 	defer->status = ASYNC_DEFERRED_STATUS_FAILED;
 
 	if (defer->continuation != NULL) {
-		async_awaitable_dispose_continuation(&defer->continuation);
+		async_awaitable_trigger_continuation(&defer->continuation, NULL, 0);
 	}
 
 	zval_ptr_dtor(&defer->result);

--- a/src/deferred.c
+++ b/src/deferred.c
@@ -383,12 +383,7 @@ ZEND_METHOD(Deferred, combine)
 	fci.no_separation = 1;
 
 	ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(args), entry) {
-		if (Z_TYPE_P(entry) != IS_OBJECT) {
-			zend_throw_error(zend_ce_type_error, "All input elements must be awaitable");
-			return;
-		}
-
-		ce = Z_OBJCE_P(entry);
+		ce = (Z_TYPE_P(entry) == IS_OBJECT) ? Z_OBJCE_P(entry) : NULL;
 
 		if (ce != async_task_ce && ce != async_deferred_awaitable_ce) {
 			zend_throw_error(zend_ce_type_error, "All input elements must be awaitable");

--- a/src/fiber.c
+++ b/src/fiber.c
@@ -35,8 +35,8 @@ const zend_uchar ASYNC_FIBER_TYPE_DEFAULT = 0;
 const zend_uchar ASYNC_FIBER_STATUS_INIT = 0;
 const zend_uchar ASYNC_FIBER_STATUS_SUSPENDED = 1;
 const zend_uchar ASYNC_FIBER_STATUS_RUNNING = 2;
-const zend_uchar ASYNC_FIBER_STATUS_FINISHED = 3;
-const zend_uchar ASYNC_FIBER_STATUS_DEAD = 4;
+const zend_uchar ASYNC_FIBER_STATUS_FINISHED = ASYNC_OP_RESOLVED;
+const zend_uchar ASYNC_FIBER_STATUS_DEAD = ASYNC_OP_FAILED;
 
 static zend_object_handlers async_fiber_handlers;
 

--- a/src/fiber.c
+++ b/src/fiber.c
@@ -161,6 +161,8 @@ zend_object *async_fiber_object_create(zend_class_entry *ce)
 	zend_object_std_init(&fiber->std, ce);
 	fiber->std.handlers = &async_fiber_handlers;
 
+	fiber->id = strpprintf(16, "%016zx", (intptr_t) &fiber->std);
+
 	return &fiber->std;
 }
 
@@ -182,6 +184,8 @@ static void async_fiber_object_destroy(zend_object *object)
 	}
 
 	async_fiber_destroy(fiber->context);
+
+	zend_string_release(fiber->id);
 
 	zend_object_std_dtor(&fiber->std);
 }

--- a/src/fiber.c
+++ b/src/fiber.c
@@ -106,7 +106,7 @@ void async_fiber_run()
 	fiber->stack = NULL;
 	fiber->exec = NULL;
 
-	ZEND_ASSERT(async_fiber_yield(fiber->context));
+	ASYNC_CHECK_FATAL(!async_fiber_yield(fiber->context), "Failed to yield from fiber");
 }
 
 
@@ -174,7 +174,7 @@ static void async_fiber_object_destroy(zend_object *object)
 	if (fiber->status == ASYNC_FIBER_STATUS_SUSPENDED) {
 		fiber->status = ASYNC_FIBER_STATUS_DEAD;
 
-		ZEND_ASSERT(async_fiber_switch_to(fiber));
+		ASYNC_CHECK_FATAL(!async_fiber_switch_to(fiber), "Failed to switch to fiber");
 	}
 
 	if (fiber->status == ASYNC_FIBER_STATUS_INIT && fiber->func == NULL) {

--- a/src/task_scheduler.c
+++ b/src/task_scheduler.c
@@ -439,10 +439,7 @@ ZEND_METHOD(TaskScheduler, setDefaultScheduler)
 
 	scheduler = ASYNC_G(scheduler);
 
-	if (scheduler != NULL) {
-		zend_throw_error(NULL, "The default task scheduler must not be changed after it has been used for the first time");
-		return;
-	}
+	ASYNC_CHECK_ERROR(scheduler != NULL, "The default task scheduler must not be changed after it has been used for the first time");
 
 	scheduler = (async_task_scheduler *) Z_OBJ_P(val);
 
@@ -537,10 +534,7 @@ ZEND_METHOD(TaskLoopScheduler, dispatch)
 
 	scheduler = (async_task_scheduler *) Z_OBJ_P(getThis());
 
-	if (scheduler->dispatching) {
-		zend_throw_error(NULL, "Cannot dispatch tasks because the dispatcher is already running");
-		return;
-	}
+	ASYNC_CHECK_ERROR(scheduler->dispatching, "Cannot dispatch tasks because the dispatcher is already running");
 
 	prev = ASYNC_G(current_scheduler);
 	ASYNC_G(current_scheduler) = scheduler;

--- a/src/task_scheduler.c
+++ b/src/task_scheduler.c
@@ -73,8 +73,6 @@ zend_bool async_task_scheduler_enqueue(async_task *task)
 
 	scheduler = task->scheduler;
 
-	ZEND_ASSERT(scheduler != NULL);
-
 	if (task->fiber.status == ASYNC_FIBER_STATUS_INIT) {
 		task->operation = ASYNC_TASK_OPERATION_START;
 	} else if (task->fiber.status == ASYNC_FIBER_STATUS_SUSPENDED) {
@@ -204,7 +202,7 @@ static void async_task_scheduler_run(async_task_scheduler *scheduler)
 			fiber->status = ASYNC_FIBER_STATUS_SUSPENDED;
 
 			ASYNC_FIBER_BACKUP_EG(fiber->stack, stack_page_size, fiber->exec);
-			async_fiber_yield(fiber->context);
+			ZEND_ASSERT(async_fiber_yield(fiber->context));
 			ASYNC_FIBER_RESTORE_EG(fiber->stack, stack_page_size, fiber->exec);
 		}
 	}
@@ -235,8 +233,8 @@ void async_task_scheduler_run_loop(async_task_scheduler *scheduler)
 			fiber->stack_size = 1024 * 1024 * 64;
 
 			fiber->context = async_fiber_create_context();
-			ZEND_ASSERT(fiber->context != NULL);
 
+			ZEND_ASSERT(fiber->context != NULL);
 			ZEND_ASSERT(async_fiber_create(fiber->context, async_fiber_run, fiber->stack_size));
 
 			fiber->stack = (zend_vm_stack) emalloc(ASYNC_FIBER_VM_STACK_SIZE);

--- a/src/task_scheduler.c
+++ b/src/task_scheduler.c
@@ -173,22 +173,6 @@ static void async_task_scheduler_run(async_task_scheduler *scheduler)
 
 				task->fiber.status = ASYNC_FIBER_STATUS_DEAD;
 			}
-
-			if (task->fiber.status == ASYNC_FIBER_STATUS_FINISHED) {
-				if (Z_TYPE_P(&task->result) == IS_OBJECT && instanceof_function_ex(Z_OBJCE_P(&task->result), async_awaitable_ce, 1) != 0) {
-					zend_throw_error(NULL, "Task must not return an object implementing Awaitable");
-
-					zval_ptr_dtor(&task->result);
-					ZVAL_OBJ(&task->result, EG(exception));
-					EG(exception) = NULL;
-
-					task->fiber.status = ASYNC_FIBER_STATUS_DEAD;
-				}
-
-				async_awaitable_trigger_continuation(&task->continuation, &task->result, 1);
-			} else if (task->fiber.status == ASYNC_FIBER_STATUS_DEAD) {
-				async_awaitable_trigger_continuation(&task->continuation, &task->result, 0);
-			}
 		}
 
 		OBJ_RELEASE(&task->fiber.std);

--- a/src/task_scheduler.c
+++ b/src/task_scheduler.c
@@ -202,7 +202,7 @@ static void async_task_scheduler_run(async_task_scheduler *scheduler)
 			fiber->status = ASYNC_FIBER_STATUS_SUSPENDED;
 
 			ASYNC_FIBER_BACKUP_EG(fiber->stack, stack_page_size, fiber->exec);
-			ZEND_ASSERT(async_fiber_yield(fiber->context));
+			ASYNC_CHECK_FATAL(!async_fiber_yield(fiber->context), "Failed to yield from fiber");
 			ASYNC_FIBER_RESTORE_EG(fiber->stack, stack_page_size, fiber->exec);
 		}
 	}
@@ -234,8 +234,8 @@ void async_task_scheduler_run_loop(async_task_scheduler *scheduler)
 
 			fiber->context = async_fiber_create_context();
 
-			ZEND_ASSERT(fiber->context != NULL);
-			ZEND_ASSERT(async_fiber_create(fiber->context, async_fiber_run, fiber->stack_size));
+			ASYNC_CHECK_FATAL(fiber->context == NULL, "Failed to create native fiber context");
+			ASYNC_CHECK_FATAL(!async_fiber_create(fiber->context, async_fiber_run, fiber->stack_size), "Failed to create native fiber");
 
 			fiber->stack = (zend_vm_stack) emalloc(ASYNC_FIBER_VM_STACK_SIZE);
 			fiber->stack->top = ZEND_VM_STACK_ELEMENTS(fiber->stack) + 1;
@@ -245,7 +245,7 @@ void async_task_scheduler_run_loop(async_task_scheduler *scheduler)
 			scheduler->fiber = fiber;
 		}
 
-		ZEND_ASSERT(async_fiber_switch_to(scheduler->fiber));
+		ASYNC_CHECK_FATAL(!async_fiber_switch_to(scheduler->fiber), "Failed to switch to fiber");
 	} else {
 		async_task_scheduler_run(scheduler);
 

--- a/src/task_scheduler.c
+++ b/src/task_scheduler.c
@@ -520,11 +520,11 @@ static void async_task_loop_scheduler_object_destroy(zend_object *object)
 	zend_object_std_dtor(&scheduler->std);
 }
 
-ZEND_METHOD(TaskLoopScheduler, activate) { }
+ZEND_METHOD(LoopTaskScheduler, activate) { }
 
-ZEND_METHOD(TaskLoopScheduler, runLoop) { }
+ZEND_METHOD(LoopTaskScheduler, runLoop) { }
 
-ZEND_METHOD(TaskLoopScheduler, dispatch)
+ZEND_METHOD(LoopTaskScheduler, dispatch)
 {
 	async_task_scheduler *scheduler;
 	async_task_scheduler *prev;
@@ -554,9 +554,9 @@ ZEND_BEGIN_ARG_INFO(arginfo_task_loop_scheduler_dispatch, 0)
 ZEND_END_ARG_INFO()
 
 static const zend_function_entry task_loop_scheduler_functions[] = {
-	ZEND_ME(TaskLoopScheduler, activate, arginfo_task_loop_scheduler_activate, ZEND_ACC_PROTECTED | ZEND_ACC_ABSTRACT)
-	ZEND_ME(TaskLoopScheduler, runLoop, arginfo_task_loop_scheduler_run_loop, ZEND_ACC_PROTECTED | ZEND_ACC_ABSTRACT)
-	ZEND_ME(TaskLoopScheduler, dispatch, arginfo_task_loop_scheduler_dispatch, ZEND_ACC_PROTECTED | ZEND_ACC_FINAL)
+	ZEND_ME(LoopTaskScheduler, activate, arginfo_task_loop_scheduler_activate, ZEND_ACC_PROTECTED | ZEND_ACC_ABSTRACT)
+	ZEND_ME(LoopTaskScheduler, runLoop, arginfo_task_loop_scheduler_run_loop, ZEND_ACC_PROTECTED | ZEND_ACC_ABSTRACT)
+	ZEND_ME(LoopTaskScheduler, dispatch, arginfo_task_loop_scheduler_dispatch, ZEND_ACC_PROTECTED | ZEND_ACC_FINAL)
 	ZEND_FE_END
 };
 
@@ -577,7 +577,7 @@ void async_task_scheduler_ce_register()
 	async_task_scheduler_handlers.free_obj = async_task_scheduler_object_destroy;
 	async_task_scheduler_handlers.clone_obj = NULL;
 
-	INIT_CLASS_ENTRY(ce, "Concurrent\\TaskLoopScheduler", task_loop_scheduler_functions);
+	INIT_CLASS_ENTRY(ce, "Concurrent\\LoopTaskScheduler", task_loop_scheduler_functions);
 	async_task_loop_scheduler_ce = zend_register_internal_class_ex(&ce, async_task_scheduler_ce);
 	async_task_loop_scheduler_ce->create_object = async_task_loop_scheduler_object_create;
 	async_task_loop_scheduler_ce->serialize = zend_class_serialize_deny;

--- a/src/task_scheduler.c
+++ b/src/task_scheduler.c
@@ -246,6 +246,11 @@ void async_task_scheduler_run_loop(async_task_scheduler *scheduler)
 		}
 
 		ASYNC_CHECK_FATAL(!async_fiber_switch_to(scheduler->fiber), "Failed to switch to fiber");
+
+		if (scheduler->running == 0) {
+			OBJ_RELEASE(&scheduler->fiber->std);
+			scheduler->fiber = NULL;
+		}
 	} else {
 		async_task_scheduler_run(scheduler);
 

--- a/tests/016-fiber-destroyed-during-suspend.phpt
+++ b/tests/016-fiber-destroyed-during-suspend.phpt
@@ -42,6 +42,6 @@ var_dump('SCRIPT END');
 string(5) "START"
 string(7) "DISPOSE"
 string(24) "Fiber has been destroyed"
-string(45) "Cannot yield from a fiber that is not running"
+string(24) "Fiber has been destroyed"
 string(4) "DONE"
 string(10) "SCRIPT END"

--- a/tests/105-task-activator.phpt
+++ b/tests/105-task-activator.phpt
@@ -26,6 +26,11 @@ $scheduler = new class() extends LoopTaskScheduler
         
         var_dump('END LOOP!');
     }
+    
+    protected function stopLoop()
+    {
+        var_dump('STOP LOOP!');
+    }
 };
 
 $work = function (string $v): void {

--- a/tests/105-task-activator.phpt
+++ b/tests/105-task-activator.phpt
@@ -9,11 +9,22 @@ if (!extension_loaded('task')) echo 'Test requires the task extension to be load
 
 namespace Concurrent;
 
-$scheduler = new class() extends TaskScheduler
+$scheduler = new class() extends TaskLoopScheduler
 {
     protected function activate()
     {
         var_dump('ACTIVATE!');
+    }
+    
+    protected function runLoop()
+    {
+        var_dump('RUN LOOP!');
+        
+        while ($this->count()) {
+            $this->dispatch();
+        }
+        
+        var_dump('END LOOP!');
     }
 };
 
@@ -21,7 +32,11 @@ $work = function (string $v): void {
     var_dump($v);
 };
 
+var_dump('MAIN');
+
 $scheduler->run($work, 'A');
+
+var_dump('MAIN');
 
 $scheduler->run(function () use ($work) {
     $work('B');
@@ -29,18 +44,32 @@ $scheduler->run(function () use ($work) {
     Task::async($work, 'C');
 });
 
+var_dump('MAIN');
+
 $scheduler->run(function () use ($work) {
     Task::async($work, 'D');
     Task::async($work, 'E');
 });
 
+var_dump('MAIN');
+
 ?>
 --EXPECT--
+string(4) "MAIN"
 string(9) "ACTIVATE!"
+string(9) "RUN LOOP!"
 string(1) "A"
+string(9) "END LOOP!"
+string(4) "MAIN"
 string(9) "ACTIVATE!"
+string(9) "RUN LOOP!"
 string(1) "B"
 string(1) "C"
+string(9) "END LOOP!"
+string(4) "MAIN"
 string(9) "ACTIVATE!"
+string(9) "RUN LOOP!"
 string(1) "D"
 string(1) "E"
+string(9) "END LOOP!"
+string(4) "MAIN"

--- a/tests/105-task-activator.phpt
+++ b/tests/105-task-activator.phpt
@@ -9,7 +9,7 @@ if (!extension_loaded('task')) echo 'Test requires the task extension to be load
 
 namespace Concurrent;
 
-$scheduler = new class() extends TaskLoopScheduler
+$scheduler = new class() extends LoopTaskScheduler
 {
     protected function activate()
     {

--- a/tests/106-task-custom-default-scheduler.phpt
+++ b/tests/106-task-custom-default-scheduler.phpt
@@ -9,7 +9,7 @@ if (!extension_loaded('task')) echo 'Test requires the task extension to be load
 
 namespace Concurrent;
 
-TaskScheduler::setDefaultScheduler(new class() extends TaskLoopScheduler
+TaskScheduler::setDefaultScheduler(new class() extends LoopTaskScheduler
 {
     protected function activate()
     {

--- a/tests/106-task-custom-default-scheduler.phpt
+++ b/tests/106-task-custom-default-scheduler.phpt
@@ -18,9 +18,16 @@ TaskScheduler::setDefaultScheduler(new class() extends LoopTaskScheduler
     
     protected function runLoop()
     {
+        var_dump('LOOP');
         while ($this->count()) {
             $this->dispatch();
         }
+        var_dump('DONE');
+    }
+    
+    protected function stopLoop()
+    {
+        var_dump('STOP!');
     }
 });
 
@@ -57,12 +64,25 @@ var_dump('MAIN');
 string(4) "MAIN"
 string(9) "ACTIVATE!"
 string(4) "MAIN"
+string(4) "LOOP"
 string(1) "A"
+string(5) "STOP!"
+string(4) "DONE"
 string(4) "MAIN"
+string(9) "ACTIVATE!"
+string(4) "LOOP"
 string(1) "B"
-string(4) "MAIN"
+string(5) "STOP!"
 string(1) "C"
-string(1) "D"
+string(4) "DONE"
 string(4) "MAIN"
+string(9) "ACTIVATE!"
+string(4) "LOOP"
+string(1) "D"
+string(5) "STOP!"
 string(1) "E"
 string(1) "F"
+string(4) "DONE"
+string(4) "MAIN"
+string(4) "LOOP"
+string(4) "DONE"

--- a/tests/106-task-custom-default-scheduler.phpt
+++ b/tests/106-task-custom-default-scheduler.phpt
@@ -9,11 +9,18 @@ if (!extension_loaded('task')) echo 'Test requires the task extension to be load
 
 namespace Concurrent;
 
-TaskScheduler::setDefaultScheduler(new class() extends TaskScheduler
+TaskScheduler::setDefaultScheduler(new class() extends TaskLoopScheduler
 {
     protected function activate()
     {
         var_dump('ACTIVATE!');
+    }
+    
+    protected function runLoop()
+    {
+        while ($this->count()) {
+            $this->dispatch();
+        }
     }
 });
 
@@ -21,26 +28,41 @@ $work = function (string $v): void {
     var_dump($v);
 };
 
-Task::await(Task::async($work, 'A'));
+var_dump('MAIN');
 
+$t = Task::async($work, 'A');
+
+var_dump('MAIN');
+Task::await($t);
+
+var_dump('MAIN');
 Task::await(Task::async(function () use ($work) {
     $work('B');
     
     Task::async($work, 'C');
 }));
 
+var_dump('MAIN');
 Task::await(Task::async(function () use ($work) {
-    Task::async($work, 'D');
     Task::async($work, 'E');
+    Task::async($work, 'F');
+    
+    var_dump('D');
 }));
+
+var_dump('MAIN');
 
 ?>
 --EXPECT--
+string(4) "MAIN"
 string(9) "ACTIVATE!"
+string(4) "MAIN"
 string(1) "A"
-string(9) "ACTIVATE!"
+string(4) "MAIN"
 string(1) "B"
+string(4) "MAIN"
 string(1) "C"
-string(9) "ACTIVATE!"
 string(1) "D"
+string(4) "MAIN"
 string(1) "E"
+string(1) "F"

--- a/tests/114-task-disposal.phpt
+++ b/tests/114-task-disposal.phpt
@@ -10,11 +10,31 @@ if (!extension_loaded('task')) echo 'Test requires the task extension to be load
 namespace Concurrent;
 
 try {
-    return Task::await((new Deferred())->awaitable());
+    Task::await((new Deferred())->awaitable());
+} catch (\Throwable $e) {
+    var_dump($e->getMessage());
+}
+
+try {
+    Task::await(Task::async(function () {
+        return Task::await((new Deferred())->awaitable());
+    }));
+} catch (\Throwable $e) {
+    var_dump($e->getMessage());
+}
+
+try {
+    Task::await(Task::async(function () {
+        return Task::await(Task::async(function () {
+            return Task::await((new Deferred())->awaitable());
+        }));
+    }));
 } catch (\Throwable $e) {
     var_dump($e->getMessage());
 }
 
 ?>
 --EXPECT--
+string(31) "Awaitable has not been resolved"
+string(31) "Awaitable has not been resolved"
 string(31) "Awaitable has not been resolved"

--- a/tests/115-task-root-await-deferred.phpt
+++ b/tests/115-task-root-await-deferred.phpt
@@ -32,6 +32,10 @@ TaskScheduler::setDefaultScheduler(new class() extends LoopTaskScheduler {
         }
         var_dump('END');
     }
+    
+    protected function stopLoop() {
+        var_dump('STOP');
+    }
 });
 
 $defer = new Deferred();

--- a/tests/115-task-root-await-deferred.phpt
+++ b/tests/115-task-root-await-deferred.phpt
@@ -1,0 +1,53 @@
+--TEST--
+Task await on root level will not need a scheduler for resolved deferreds.
+--SKIPIF--
+<?php
+if (!extension_loaded('task')) echo 'Test requires the task extension to be loaded';
+?>
+--FILE--
+<?php
+
+namespace Concurrent;
+
+var_dump(Task::await(123));
+
+var_dump(Task::await(Deferred::value(321)));
+
+try {
+    Task::await(Deferred::error(new \Error('Fail!')));
+} catch (\Throwable $e) {
+    var_dump($e->getMessage());
+}
+
+TaskScheduler::setDefaultScheduler(new class() extends LoopTaskScheduler {
+    protected function activate() {
+        var_dump('ACTIVATE');
+        $this->dispatch();
+    }
+    
+    protected function runLoop() {
+        var_dump('START');
+        while ($this->count()) {
+            $this->dispatch();
+        }
+        var_dump('END');
+    }
+});
+
+$defer = new Deferred();
+
+Task::async(function () use ($defer) {
+    $defer->resolve(777);
+});
+
+var_dump(Task::await($defer->awaitable()));
+
+?>
+--EXPECT--
+int(123)
+int(321)
+string(5) "Fail!"
+string(8) "ACTIVATE"
+int(777)
+string(5) "START"
+string(3) "END"

--- a/tests/116-task-timer-loop.phpt
+++ b/tests/116-task-timer-loop.phpt
@@ -47,7 +47,11 @@ $result = $scheduler->run(function () use ($loop) {
         $defer->resolve('D');
     });
     
-    return Task::await($defer->awaitable());
+    $t = Task::async(function () use ($defer) {
+        return Task::await($defer->awaitable());
+    });
+    
+    return Task::await($t);
 });
 
 var_dump($result);

--- a/tests/116-task-timer-loop.phpt
+++ b/tests/116-task-timer-loop.phpt
@@ -1,0 +1,60 @@
+--TEST--
+Task scheduler can be combiend with an event loop.
+--SKIPIF--
+<?php
+if (!extension_loaded('task')) echo 'Test requires the task extension to be loaded';
+?>
+--FILE--
+<?php
+
+namespace Concurrent;
+
+require_once __DIR__ . '/loop-scheduler.inc';
+
+$loop = new TimerLoop();
+$scheduler = new TimerLoopScheduler($loop);
+
+$result = $scheduler->run(function () {
+    return 'A';
+});
+
+var_dump($result);
+
+$result = $scheduler->run(function () use ($loop) {
+    $defer = new Deferred();
+    
+    $loop->nextTick(function () use ($defer) {
+        $defer->resolve('B');
+    });
+    
+    return Task::await($defer->awaitable());
+});
+
+var_dump($result);
+
+$result = $scheduler->run(function () use ($loop) {
+    $defer = new Deferred();
+    
+    $loop->timer(100, function () use ($defer) {
+        $defer->resolve('C');
+    });
+    
+    var_dump(Task::await($defer->awaitable()));
+    
+    $defer = new Deferred();
+    
+    $loop->timer(100, function () use ($defer) {
+        $defer->resolve('D');
+    });
+    
+    return Task::await($defer->awaitable());
+});
+
+var_dump($result);
+
+?>
+--EXPECT--
+string(1) "A"
+string(1) "B"
+string(1) "C"
+string(1) "D"

--- a/tests/117-task-timer-default-loop.phpt
+++ b/tests/117-task-timer-default-loop.phpt
@@ -1,0 +1,49 @@
+--TEST--
+Task scheduler (used as default) can be combiend with an event loop.
+--SKIPIF--
+<?php
+if (!extension_loaded('task')) echo 'Test requires the task extension to be loaded';
+?>
+--FILE--
+<?php
+
+namespace Concurrent;
+
+require_once __DIR__ . '/loop-scheduler.inc';
+
+$loop = new TimerLoop();
+
+TaskScheduler::setDefaultScheduler(new TimerLoopScheduler($loop));
+
+var_dump(Task::await('A'));
+
+$defer = new Deferred();
+
+$loop->nextTick(function () use ($defer) {
+    $defer->resolve('B');
+});
+
+var_dump(Task::await($defer->awaitable()));
+
+$defer = new Deferred();
+
+$loop->timer(100, function () use ($defer) {
+    $defer->resolve('C');
+});
+
+var_dump(Task::await($defer->awaitable()));
+
+$defer = new Deferred();
+
+$loop->timer(100, function () use ($defer) {
+    $defer->resolve('D');
+});
+
+var_dump(Task::await($defer->awaitable()));
+
+?>
+--EXPECT--
+string(1) "A"
+string(1) "B"
+string(1) "C"
+string(1) "D"

--- a/tests/117-task-timer-default-loop.phpt
+++ b/tests/117-task-timer-default-loop.phpt
@@ -39,7 +39,11 @@ $loop->timer(100, function () use ($defer) {
     $defer->resolve('D');
 });
 
-var_dump(Task::await($defer->awaitable()));
+$t = Task::async(function () use ($defer) {
+    return Task::await($defer->awaitable());
+});
+
+var_dump(Task::await($t));
 
 ?>
 --EXPECT--

--- a/tests/loop-scheduler.inc
+++ b/tests/loop-scheduler.inc
@@ -26,6 +26,8 @@ class TimerLoop
     
     protected $timers;
     
+    protected $running = false;
+    
     public function __construct()
     {
         $this->timers = new \SplPriorityQueue();
@@ -48,7 +50,9 @@ class TimerLoop
     
     public function run()
     {
-        while ($this->ticks || !$this->timers->isEmpty()) {
+        $this->running = true;
+        
+        while ($this->running && ($this->ticks || !$this->timers->isEmpty())) {
             $ticks = $this->ticks;
             $this->ticks = [];
             
@@ -82,6 +86,11 @@ class TimerLoop
             }
         }
     }
+    
+    public function stop()
+    {
+        $this->running = false;
+    }
 }
 
 class TimerLoopScheduler extends LoopTaskScheduler
@@ -104,5 +113,10 @@ class TimerLoopScheduler extends LoopTaskScheduler
     protected function runLoop()
     {
         $this->loop->run();
+    }
+    
+    protected function stopLoop()
+    {
+        $this->loop->stop();
     }
 }

--- a/tests/loop-scheduler.inc
+++ b/tests/loop-scheduler.inc
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ +----------------------------------------------------------------------+
+ | PHP Version 7                                                        |
+ +----------------------------------------------------------------------+
+ | Copyright (c) 1997-2018 The PHP Group                                |
+ +----------------------------------------------------------------------+
+ | This source file is subject to version 3.01 of the PHP license,      |
+ | that is bundled with this package in the file LICENSE, and is        |
+ | available through the world-wide-web at the following url:           |
+ | http://www.php.net/license/3_01.txt                                  |
+ | If you did not receive a copy of the PHP license and are unable to   |
+ | obtain it through the world-wide-web, please send a note to          |
+ | license@php.net so we can mail you a copy immediately.               |
+ +----------------------------------------------------------------------+
+ | Authors: Martin Schröder <m.schroeder2007@gmail.com>                 |
+ +----------------------------------------------------------------------+
+ */
+
+namespace Concurrent;
+
+class TimerLoop
+{
+    protected $ticks = [];
+    
+    protected $timers;
+    
+    public function __construct()
+    {
+        $this->timers = new \SplPriorityQueue();
+    }
+    
+    public function nextTick(callable $callback)
+    {
+        $this->ticks[] = $callback;
+    }
+    
+    public function timer(int $delay, callable $callback)
+    {
+        $due = \microtime(true) + ($delay / 1000);
+        
+        $this->timers->insert([
+            $due,
+            $callback
+        ], -1 * $due);
+    }
+    
+    public function run()
+    {
+        while ($this->ticks || !$this->timers->isEmpty()) {
+            $ticks = $this->ticks;
+            $this->ticks = [];
+            
+            foreach ($ticks as $callback) {
+                $callback();
+            }
+            
+            if ($this->timers->isEmpty()) {
+                continue;
+            }
+            
+            $now = \microtime(true);
+            $sleep = null;
+            
+            do {
+                list ($due, $callback) = $this->timers->top();
+                
+                if ($due > $now) {
+                    $sleep = ($due - $now) * 1000000;
+                    
+                    break;
+                }
+                
+                $this->timers->extract();
+                
+                $callback();
+            } while (!$this->timers->isEmpty());
+            
+            if ($sleep !== null) {
+                \usleep($sleep);
+            }
+        }
+    }
+}
+
+class TimerLoopScheduler extends LoopTaskScheduler
+{
+    private $loop;
+    
+    public function __construct(TimerLoop $loop)
+    {
+        $this->loop = $loop;
+    }
+    
+    protected function activate()
+    {
+        $this->loop->nextTick(\Closure::fromCallable([
+            $this,
+            'dispatch'
+        ]));
+    }
+    
+    protected function runLoop()
+    {
+        $this->loop->run();
+    }
+}


### PR DESCRIPTION
This PR introduces the new `TaskLoopScheduler` that is a specialized scheduler to be used for integration of async tasks with event loops. As suggested by @kelunik in #23 it runs the event loop in another fiber to improve the performance of root-level awaits and to avoid the need to stop the event loop at all.