### PR TITLE
Stacked Task Schedulers

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ class TaskScheduler implements \Countable
     
     public final function runWithContext(Context $context, callable $callback, ...$args): mixed { }
     
-    public static final function setDefaultScheduler(TaskScheduler $scheduler): void { }
+    public static final function push(TaskScheduler $scheduler): void { }
+    
+    public static final function pop(TaskScheduler $scheduler): void { }
 }
 ```
 

--- a/examples/b.php
+++ b/examples/b.php
@@ -12,7 +12,7 @@ register_shutdown_function(function () {
     echo "===> Shutdown function(s) execute here.\n";
 });
 
-TaskScheduler::setDefaultScheduler(new class($loop) extends LoopTaskScheduler {
+TaskScheduler::push(new class($loop) extends LoopTaskScheduler {
 
     protected $loop;
 

--- a/include/task_scheduler.h
+++ b/include/task_scheduler.h
@@ -27,11 +27,18 @@ typedef struct _async_task async_task;
 BEGIN_EXTERN_C()
 
 typedef struct _async_task_scheduler async_task_scheduler;
+typedef struct _async_task_scheduler_stack async_task_scheduler_stack;
+typedef struct _async_task_scheduler_stack_entry async_task_scheduler_stack_entry;
 typedef struct _async_task_queue async_task_queue;
 
 struct _async_task_queue {
+	/* Number of queued tasks. */
 	size_t size;
+
+	/* First task in the queue, used by dequeue(). */
 	async_task *first;
+
+	/* Last task in the queue, used by enqueue(). */
 	async_task *last;
 };
 
@@ -41,6 +48,9 @@ struct _async_task_scheduler {
 
 	/* Is set while an event loop is running. */
 	zend_bool running;
+
+	/* Has the scheduler been modified since the last call to run. */
+	zend_bool modified;
 
 	/* Is set while the scheduler is in the process of dispatching tasks. */
 	zend_bool dispatching;
@@ -57,8 +67,24 @@ struct _async_task_scheduler {
 	/* Tasks that are suspended. */
 	async_task_queue suspended;
 
-	/* Task PHP object handle. */
+	/* PHP object handle. */
 	zend_object std;
+};
+
+struct _async_task_scheduler_stack_entry {
+	/* Refers to the task scheduler. */
+	async_task_scheduler *scheduler;
+
+	/* Points to the previous scheduler, NULL if no stacked scheduler is active. */
+	async_task_scheduler_stack_entry *prev;
+};
+
+struct _async_task_scheduler_stack {
+	/* Number of stacked schedulers. */
+	size_t size;
+
+	/* Top-most scheduler on the stack. */
+	async_task_scheduler_stack_entry *top;
 };
 
 async_task_scheduler *async_task_scheduler_get();

--- a/lib/AsyncTestCase.php
+++ b/lib/AsyncTestCase.php
@@ -22,17 +22,32 @@ namespace Concurrent;
 
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Base class for tests that make use of async tasks.
+ */
 abstract class AsyncTestCase extends TestCase
 {
+    /**
+     * Create the task scheduler being used for a test.
+     * 
+     * The scheduler is re-created for every test to ensure proper test isolation.
+     */
     protected function createTaskScheduler(): TaskScheduler
     {
         return new TaskScheduler();
     }
 
+    /**
+     * Run the test method in an isolated task scheduler.
+     */
     protected function runTest()
     {
-        return $this->createTaskScheduler()->run(function () {
+        TaskScheduler::push($scheduler = $this->createTaskScheduler());
+        
+        try {
             return parent::runTest();
-        });
+        } finally {
+            TaskScheduler::pop($scheduler);
+        }
     }
 }

--- a/lib/stubs.php
+++ b/lib/stubs.php
@@ -176,11 +176,14 @@ class TaskScheduler implements \Countable
     public final function runWithContext(Context $context, callable $callback, ...$args) { }
     
     /**
-     * Sets the default task scheduler implementations.
-     * 
-     * This method must be called before any async tasks are created or awaited!
+     * Push the given scheduler as default scheduler.
      */
-    public static final function setDefaultScheduler(TaskScheduler $scheduler): void { }
+    public static final function push(TaskScheduler $scheduler): void { }
+    
+    /**
+     * Pop the given scheduler if it is the active scheduler.
+     */
+    public static final function pop(TaskScheduler $scheduler): void { }
 }
 
 /**

--- a/php_async.c
+++ b/php_async.c
@@ -35,7 +35,6 @@ static void (*orig_execute_ex)(zend_execute_data *exec);
 static void async_execute_ex(zend_execute_data *exec)
 {
 	async_fiber *fiber;
-	async_task_scheduler *scheduler;
 
 	fiber = ASYNC_G(current_fiber);
 
@@ -44,11 +43,7 @@ static void async_execute_ex(zend_execute_data *exec)
 	}
 
 	if (fiber == NULL && exec->prev_execute_data == NULL) {
-		scheduler = ASYNC_G(scheduler);
-
-		if (scheduler != NULL) {
-			async_task_scheduler_run_loop(scheduler);
-		}
+		async_task_scheduler_shutdown();
 	}
 }
 
@@ -98,6 +93,7 @@ PHP_MINIT_FUNCTION(async)
 
 PHP_MSHUTDOWN_FUNCTION(async)
 {
+	async_task_scheduler_shutdown();
 	async_task_scheduler_ce_unregister();
 	async_fiber_ce_unregister();
 

--- a/php_async.h
+++ b/php_async.h
@@ -59,8 +59,11 @@ ZEND_BEGIN_MODULE_GLOBALS(async)
 	/* Active task context. */
 	async_context *current_context;
 
-	/* Default shared task scheduler. */
+	/* Fallback root task scheduler. */
 	async_task_scheduler *scheduler;
+
+	/* Stack of registered default schedulers. */
+	async_task_scheduler_stack *scheduler_stack;
 
 	/* Running task scheduler. */
 	async_task_scheduler *current_scheduler;

--- a/src/task_scheduler.c
+++ b/src/task_scheduler.c
@@ -27,8 +27,8 @@
 
 ZEND_DECLARE_MODULE_GLOBALS(async)
 
-zend_class_entry *async_task_scheduler_ce;
-zend_class_entry *async_loop_task_scheduler_ce;
+static zend_class_entry *async_task_scheduler_ce;
+static zend_class_entry *async_loop_task_scheduler_ce;
 
 static zend_object_handlers async_task_scheduler_handlers;
 static zend_object_handlers async_loop_task_scheduler_handlers;
@@ -579,7 +579,7 @@ ZEND_METHOD(TaskScheduler, pop)
 
 	stack = ASYNC_G(scheduler_stack);
 
-	ASYNC_CHECK_ERROR(stack == NULL || stack->top == NULL, "Cannot pop task scheduler that has not been pushed");
+	ASYNC_CHECK_ERROR(stack == NULL || stack->top == NULL, "Cannot pop task scheduler because it is not the active scheduler");
 
 	scheduler = async_task_scheduler_obj(Z_OBJ_P(val));
 

--- a/src/task_scheduler.c
+++ b/src/task_scheduler.c
@@ -404,7 +404,6 @@ static void async_task_scheduler_object_destroy(zend_object *object)
 
 	async_task_scheduler_dispose(scheduler);
 
-	zend_objects_destroy_object(object);
 	zend_object_std_dtor(object);
 }
 
@@ -746,7 +745,6 @@ void async_task_scheduler_ce_register()
 
 	memcpy(&async_task_scheduler_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	async_task_scheduler_handlers.offset = XtOffsetOf(async_task_scheduler, std);
-	async_task_scheduler_handlers.dtor_obj = async_task_scheduler_object_destroy;
 	async_task_scheduler_handlers.free_obj = async_task_scheduler_object_destroy;
 	async_task_scheduler_handlers.clone_obj = NULL;
 
@@ -759,7 +757,6 @@ void async_task_scheduler_ce_register()
 
 	memcpy(&async_loop_task_scheduler_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	async_loop_task_scheduler_handlers.offset = XtOffsetOf(async_task_scheduler, std);
-	async_loop_task_scheduler_handlers.dtor_obj = async_task_scheduler_object_destroy;
 	async_loop_task_scheduler_handlers.free_obj = async_task_scheduler_object_destroy;
 	async_loop_task_scheduler_handlers.clone_obj = NULL;
 

--- a/tests/106-task-custom-default-scheduler.phpt
+++ b/tests/106-task-custom-default-scheduler.phpt
@@ -9,7 +9,7 @@ if (!extension_loaded('task')) echo 'Test requires the task extension to be load
 
 namespace Concurrent;
 
-TaskScheduler::setDefaultScheduler(new class() extends LoopTaskScheduler
+TaskScheduler::push(new class() extends LoopTaskScheduler
 {
     protected function activate()
     {

--- a/tests/111-task-inlining.phpt
+++ b/tests/111-task-inlining.phpt
@@ -16,7 +16,7 @@ $var = new ContextVar();
 $context = Context::current();
 $context = $context->with($var, 123);
 
-$scheduler->runWithContext($context, function () use ($var) {
+$scheduler->runWithContext($context, function (ContextVar $var) {
     $callback = function () use ($var) {
         return $var->get();
     };
@@ -38,7 +38,7 @@ $scheduler->runWithContext($context, function () use ($var) {
     } catch (\Throwable $e) {
         var_dump($e->getMessage());
     }
-});
+}, $var);
 
 ?>
 --EXPECT--

--- a/tests/115-task-root-await-deferred.phpt
+++ b/tests/115-task-root-await-deferred.phpt
@@ -9,7 +9,7 @@ if (!extension_loaded('task')) echo 'Test requires the task extension to be load
 
 namespace Concurrent;
 
-TaskScheduler::setDefaultScheduler(new class() extends LoopTaskScheduler {
+TaskScheduler::push(new class() extends LoopTaskScheduler {
     protected function activate() {
         var_dump('ACTIVATE');
     }

--- a/tests/117-task-timer-default-loop.phpt
+++ b/tests/117-task-timer-default-loop.phpt
@@ -13,7 +13,7 @@ require_once __DIR__ . '/loop-scheduler.inc';
 
 $loop = new TimerLoop();
 
-TaskScheduler::setDefaultScheduler(new TimerLoopScheduler($loop));
+TaskScheduler::push(new TimerLoopScheduler($loop));
 
 var_dump(Task::await('A'));
 

--- a/tests/121-task-scheduler-stacking.phpt
+++ b/tests/121-task-scheduler-stacking.phpt
@@ -1,0 +1,60 @@
+--TEST--
+Task schedulers can be stacked and unstacked.
+--SKIPIF--
+<?php
+if (!extension_loaded('task')) echo 'Test requires the task extension to be loaded';
+?>
+--FILE--
+<?php
+
+namespace Concurrent;
+
+class TestScheduler extends LoopTaskScheduler {
+    private $name;
+    
+    public function __construct(string $name) {
+        $this->name = $name;
+    }
+    
+    protected function activate() {
+        var_dump($this->name);
+    }
+    
+    protected function runLoop() {
+        $this->dispatch();
+    }
+    
+    protected function stopLoop() { }
+}
+
+TaskScheduler::push($s1 = new TestScheduler('S1'));
+
+Task::await(Task::async('var_dump', 'A'));
+
+TaskScheduler::push($s2 = new TestScheduler('S2'));
+
+$t = Task::async('var_dump', 'B');
+Task::async('var_dump', 'C');
+
+Task::await($t);
+
+TaskScheduler::pop($s2);
+
+Task::await(Task::async('var_dump', 'D'));
+Task::async('var_dump', 'E');
+
+TaskScheduler::pop($s1);
+
+Task::await(Task::async('var_dump', 'X'));
+
+--EXPECT--
+string(2) "S1"
+string(1) "A"
+string(2) "S2"
+string(1) "B"
+string(1) "C"
+string(2) "S1"
+string(1) "D"
+string(2) "S1"
+string(1) "E"
+string(1) "X"

--- a/tests/122-task-scheduler-pop-validation.phpt
+++ b/tests/122-task-scheduler-pop-validation.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Task schedulers cannot be popped while they are not active.
+--SKIPIF--
+<?php
+if (!extension_loaded('task')) echo 'Test requires the task extension to be loaded';
+?>
+--FILE--
+<?php
+
+namespace Concurrent;
+
+try {
+    TaskScheduler::pop(new TaskScheduler());
+} catch (\Throwable $e) {
+    var_dump($e->getMessage());
+}
+
+TaskScheduler::push(new TaskScheduler());
+
+try {
+    TaskScheduler::pop(new TaskScheduler());
+} catch (\Throwable $e) {
+    var_dump($e->getMessage());
+}
+
+--EXPECT--
+string(64) "Cannot pop task scheduler because it is not the active scheduler"
+string(64) "Cannot pop task scheduler because it is not the active scheduler"

--- a/vagrant-nts.sh
+++ b/vagrant-nts.sh
@@ -3,7 +3,7 @@
 PHP_VERSION=7.3.0alpha2
 
 sudo apt-get update
-sudo apt-get install git gcc make pkg-config autoconf bison libxml2-dev libssl-dev curl -y
+sudo apt-get install gdb git gcc make pkg-config autoconf bison libxml2-dev libssl-dev curl -y
 
 # Install PHP:
 sudo mkdir /usr/local/php
@@ -38,6 +38,8 @@ sudo chmod 466 /usr/local/php/cli/php.ini
 sudo ln -s /usr/local/php/cli/bin/php /usr/local/bin/php
 sudo ln -s /usr/local/php/cli/bin/phpize /usr/local/bin/phpize
 sudo ln -s /usr/local/php/cli/bin/php-config /usr/local/bin/php-config
+
+sudo echo "alias phpgdb='gdb $(which php)'" >> ~/.bash_aliases
 
 cd /vagrant
 

--- a/vagrant-zts.sh
+++ b/vagrant-zts.sh
@@ -37,6 +37,8 @@ sudo ln -s /usr/local/php/cli/bin/php /usr/local/bin/php
 sudo ln -s /usr/local/php/cli/bin/phpize /usr/local/bin/phpize
 sudo ln -s /usr/local/php/cli/bin/php-config /usr/local/bin/php-config
 
+sudo echo "alias phpgdb='gdb $(which php)'" >> ~/.bash_aliases
+
 cd /vagrant
 
 sudo phpize --clean


### PR DESCRIPTION
This PR introduces a stack of task schedulers instead of the default scheduler. The rationale for this is that you can set a dedicated task scheduler for each test case in unit tests. In PHPUnit this can be done eighter by extending `TestCase` and overwriting the `runTest()` method or via `TestListener` by implementing it in `startTest()` and `endTest()`.

This addresses #33, a task scheduler will run to completion and dispose of all pending tasks when it is popped from the scheduler stack.