### PR TITLE
Context Cancellation Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,17 @@ namespace Concurrent;
 
 final class Context
 {
-    public function with(ContextVar $var, $value): Context { }
-    
-    public function run(callable $callback, ...$args): mixed { }
-    
     public function isCancelled(): bool { }
     
     public function throwIfCancelled(): void { }
+    
+    public function with(ContextVar $var, $value): Context { }
+    
+    public function withTimeout(int $milliseconds): Context { }
+    
+    public function shield(): Context { }
+    
+    public function run(callable $callback, ...$args): mixed { }
     
     public static function current(): Context { }
     

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The async extension exposes a public API that can be used to create, run and int
 
 ### Awaitable
 
-This interface cannot be implemented directly by userland classes, implementations are provided by `Deferred` and `Task`.
+This interface cannot be implemented directly by userland classes, implementations are provided by `Deferred::awaitable()` and `Task`. `Awaitable` is exposed as a union type to enable proper type hinting.
 
 ```php
 namespace Concurrent;
@@ -23,11 +23,15 @@ interface Awaitable { }
 
 A deferred is a placeholder for an async operation that can be succeeded or failed from userland. It can be used to implement combinator function that operate on multiple `Awaitable` and expose a single `Awaitable` as result. The value returned from `awaitable()` is meant to be consumed by other tasks (or deferreds). The `Deferred` object itself must be kept private to the async operation because it can eighter succeed or fail the awaitable.
 
+Each `Deferred` may specify a cancellation callback as constructor argument. The callback will be triggered when the current `Context` is cancelled. It receives the `Deferred` object as first argument and the cancellation error as second argument. You must not throw an error from the callback, doing so will trigger a fatal error and terminate the script.
+
 ```php
 namespace Concurrent;
 
 final class Deferred
 {
+    public function __construct(callable $cancel = null) { }
+    
     public function awaitable(): Awaitable { }
     
     public function resolve($val = null): void { }

--- a/README.md
+++ b/README.md
@@ -117,6 +117,23 @@ final class ContextVar
 }
 ```
 
+### CancellationHandler
+
+You can use a `CancellationHandler` to inherit a cancellable `Context` from any context. The cancellation handler uses the context passed to the constructor (or the current context when no context is passed) and provides a derived context with cancellation handling via `context()`. A call to `cancel()` will cancel the provided context, the optional error argument will registered as previous error with the cancellation exception.
+
+```php
+namespace Concurrent;
+
+final class CancellationHandler
+{
+    public function __construct(?Context $context = null) { }
+    
+    public function context(): Context { }
+    
+    public function cancel(?\Throwable $e = null): void { }
+}
+```
+
 ### Timer
 
 The `Timer` class is used to schedule timers with the integrated event loop. Timers do not make use of callbacks, instead they will suspend the current task during `awaitTimeout()` and continue when the next timeout is exceeded. The first call to `awaitTimeout()` will start the timer. If additional tasks await an active the timer they will share the same timeout (which could be less than the value passed to the constructor). A `Timer` can be closed by calling `close()` which will fail all pending timeout subscriptions and prevent any further operations.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ final class Context
     
     public function run(callable $callback, ...$args): mixed { }
     
+    public function isCancelled(): bool { }
+    
+    public function throwIfCancelled(): void { }
+    
     public static function current(): Context { }
     
     public static function background(): Context { }

--- a/examples/t.php
+++ b/examples/t.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Concurrent;
+
+$handler = new CancellationHandler(Context::current());
+
+Task::asyncWithContext($handler->context(), function () {
+    $defer = new Deferred(function (Deferred $defer, ?\Throwable $e = null) {
+        var_dump('CANCEL ME!');
+        
+        $defer->resolve(777);
+    });
+    
+    var_dump(Task::await($defer->awaitable()));
+});
+
+$timer = new Timer(100);
+$timer->awaitTimeout();
+
+var_dump('KILLIT!');
+$handler->cancel();

--- a/examples/t.php
+++ b/examples/t.php
@@ -2,20 +2,18 @@
 
 namespace Concurrent;
 
-$handler = new CancellationHandler(Context::current());
-
-Task::asyncWithContext($handler->context(), function () {
-    $defer = new Deferred(function (Deferred $defer, ?\Throwable $e = null) {
-        var_dump('CANCEL ME!');
+Task::asyncWithContext(Context::current()->withTimeout(200), function () {
+    Task::asyncWithContext(Context::current()->shield(), function () {
+        (new Timer(1000))->awaitTimeout();
         
-        $defer->resolve(777);
+        var_dump('SHIELDED DONE');
     });
     
-    var_dump(Task::await($defer->awaitable()));
+    try {
+        var_dump((new Timer(1000))->awaitTimeout());
+    } catch (\Throwable $e) {
+        echo $e;
+    }
+    
+    var_dump('DONE!');
 });
-
-$timer = new Timer(100);
-$timer->awaitTimeout();
-
-var_dump('KILLIT!');
-$handler->cancel();

--- a/php_async.c
+++ b/php_async.c
@@ -239,7 +239,7 @@ static void async_gethostbyname_uv(char *name, zval *return_value, zend_execute_
 		return;
 	}
 
-	async_task_suspend(q, return_value, execute_data);
+	async_task_suspend(q, return_value, execute_data, 0);
 
 	efree(req);
 	efree(q);

--- a/php_async.h
+++ b/php_async.h
@@ -140,7 +140,7 @@ typedef struct _async_timer                         async_timer;
 typedef void* async_fiber_context;
 
 typedef void (* async_awaitable_func)(void *obj, zval *data, zval *result, zend_bool success);
-typedef void (* async_cancel_func)(void *obj, zval *error, async_cancel_cb *cb);
+typedef void (* async_cancel_func)(void *obj, zval *error);
 
 typedef void (* async_fiber_func)();
 typedef void (* async_fiber_run_func)(async_fiber *fiber);
@@ -275,8 +275,10 @@ struct _async_deferred {
 	/* Context instance (only needed if cancellation is available). */
 	async_context *context;
 
-	async_cancel_cb *cancel;
+	/* Inlined cancellation handler (saves additional memory allocation). */
+	async_cancel_cb cancel;
 
+	/* Function call info & cache of the cancel callback. */
 	zend_fcall_info fci;
 	zend_fcall_info_cache fcc;
 

--- a/php_async.h
+++ b/php_async.h
@@ -114,6 +114,10 @@ void async_task_scheduler_shutdown();
 
 typedef struct _async_awaitable_cb                  async_awaitable_cb;
 typedef struct _async_awaitable_queue               async_awaitable_queue;
+typedef struct _async_cancel_cb                     async_cancel_cb;
+typedef struct _async_cancel_queue                  async_cancel_queue;
+typedef struct _async_cancellation_handler          async_cancellation_handler;
+typedef struct _async_cancellation_handler          async_cancellation_handler;
 typedef struct _async_context                       async_context;
 typedef struct _async_context_var                   async_context_var;
 typedef struct _async_deferred                      async_deferred;
@@ -136,6 +140,7 @@ typedef struct _async_timer                         async_timer;
 typedef void* async_fiber_context;
 
 typedef void (* async_awaitable_func)(void *obj, zval *data, zval *result, zend_bool success);
+typedef void (* async_cancel_func)(void *obj, zval *error, async_cancel_cb *cancel);
 
 typedef void (* async_fiber_func)();
 typedef void (* async_fiber_run_func)(async_fiber *fiber);
@@ -190,6 +195,20 @@ struct _async_awaitable_queue {
 	async_awaitable_cb *last;
 };
 
+struct _async_cancel_cb {
+	void *object;
+	async_cancel_func func;
+	zend_fcall_info fci;
+	zend_fcall_info_cache fcc;
+	async_cancel_cb *prev;
+	async_cancel_cb *next;
+};
+
+struct _async_cancel_queue {
+	async_cancel_cb *first;
+	async_cancel_cb *last;
+};
+
 struct _async_enable_cb {
 	zend_bool active;
 	void *object;
@@ -203,6 +222,18 @@ struct _async_enable_queue {
 	async_enable_cb *last;
 };
 
+
+struct _async_cancellation_handler {
+	/* PHP object handle. */
+	zend_object std;
+
+	/* Cancellable context instance. */
+	async_context *context;
+
+	zval error;
+
+	async_cancel_queue callbacks;
+};
 
 struct _async_context {
 	/* PHP object handle. */
@@ -219,6 +250,8 @@ struct _async_context {
 
 	/* Value of the context var, defaults to zval NULL. */
 	zval value;
+
+	async_cancellation_handler *cancel;
 };
 
 struct _async_context_var {
@@ -235,6 +268,11 @@ struct _async_deferred {
 
 	/* Result (or error) value in case of resolved deferred. */
 	zval result;
+
+	/* Context instance (only needed if cancellation is available). */
+	async_context *context;
+
+	async_cancel_cb *cancel;
 
 	/* Linked list of registered continuation callbacks. */
 	async_awaitable_queue continuation;

--- a/php_async.h
+++ b/php_async.h
@@ -430,6 +430,9 @@ struct _async_task {
 	/* Current suspension point of the task. */
 	async_awaitable_cb *suspended;
 
+	/* Cancellation callback (inlined to avoid additional memory allocation). */
+	async_cancel_cb cancel;
+
 	/* Linked list of registered continuation callbacks. */
 	async_awaitable_queue continuation;
 };

--- a/php_async.h
+++ b/php_async.h
@@ -140,7 +140,7 @@ typedef struct _async_timer                         async_timer;
 typedef void* async_fiber_context;
 
 typedef void (* async_awaitable_func)(void *obj, zval *data, zval *result, zend_bool success);
-typedef void (* async_cancel_func)(void *obj, zval *error);
+typedef void (* async_cancel_func)(void *obj, zval *error, async_cancel_cb *cb);
 
 typedef void (* async_fiber_func)();
 typedef void (* async_fiber_run_func)(async_fiber *fiber);
@@ -228,8 +228,13 @@ struct _async_cancellation_handler {
 	/* Cancellable context instance. */
 	async_context *context;
 
+	/* Error that caused cancellation, UNDEF by default. */
 	zval error;
 
+	/* Chain handler that connects the cancel handler to the parent handler. */
+	async_cancel_cb chain;
+
+	/* Linked list of cancellation callbacks. */
 	async_cancel_queue callbacks;
 };
 

--- a/php_async.h
+++ b/php_async.h
@@ -228,6 +228,12 @@ struct _async_cancellation_handler {
 	/* Cancellable context instance. */
 	async_context *context;
 
+	/* Task scheduler instance (only != NULL if timeout is active). */
+	async_task_scheduler *scheduler;
+
+	/* Timeout instance (watcher is never referenced within libuv). */
+	uv_timer_t timer;
+
 	/* Error that caused cancellation, UNDEF by default. */
 	zval error;
 

--- a/php_async.h
+++ b/php_async.h
@@ -140,7 +140,7 @@ typedef struct _async_timer                         async_timer;
 typedef void* async_fiber_context;
 
 typedef void (* async_awaitable_func)(void *obj, zval *data, zval *result, zend_bool success);
-typedef void (* async_cancel_func)(void *obj, zval *error, async_cancel_cb *cancel);
+typedef void (* async_cancel_func)(void *obj, zval *error);
 
 typedef void (* async_fiber_func)();
 typedef void (* async_fiber_run_func)(async_fiber *fiber);
@@ -198,8 +198,6 @@ struct _async_awaitable_queue {
 struct _async_cancel_cb {
 	void *object;
 	async_cancel_func func;
-	zend_fcall_info fci;
-	zend_fcall_info_cache fcc;
 	async_cancel_cb *prev;
 	async_cancel_cb *next;
 };
@@ -273,6 +271,9 @@ struct _async_deferred {
 	async_context *context;
 
 	async_cancel_cb *cancel;
+
+	zend_fcall_info fci;
+	zend_fcall_info_cache fcc;
 
 	/* Linked list of registered continuation callbacks. */
 	async_awaitable_queue continuation;
@@ -528,7 +529,7 @@ ASYNC_API void async_awaitable_trigger_continuation(async_awaitable_queue *q, zv
 
 ASYNC_API async_context *async_context_get();
 
-ASYNC_API void async_task_suspend(async_awaitable_queue *q, zval *return_value, zend_execute_data *execute_data);
+ASYNC_API void async_task_suspend(async_awaitable_queue *q, zval *return_value, zend_execute_data *execute_data, zend_bool cancellable);
 
 ASYNC_API uv_loop_t *async_task_scheduler_get_loop();
 ASYNC_API async_task_scheduler *async_task_scheduler_get();

--- a/src/context.c
+++ b/src/context.c
@@ -359,7 +359,7 @@ static const zend_function_entry async_context_var_functions[] = {
 };
 
 
-static void chain_handler(void *obj, zval *error, async_cancel_cb *cb)
+static void chain_handler(void *obj, zval *error)
 {
 	async_cancellation_handler *handler;
 	async_cancel_cb *cancel;
@@ -371,7 +371,7 @@ static void chain_handler(void *obj, zval *error, async_cancel_cb *cb)
 	while (handler->callbacks.first != NULL) {
 		ASYNC_Q_DEQUEUE(&handler->callbacks, cancel);
 
-		cancel->func(cancel->object, &handler->error, cancel);
+		cancel->func(cancel->object, &handler->error);
 	}
 }
 
@@ -513,7 +513,7 @@ ZEND_METHOD(CancellationHandler, cancel)
 	while (handler->callbacks.first != NULL) {
 		ASYNC_Q_DEQUEUE(&handler->callbacks, cancel);
 
-		cancel->func(cancel->object, &handler->error, cancel);
+		cancel->func(cancel->object, &handler->error);
 	}
 }
 

--- a/src/deferred.c
+++ b/src/deferred.c
@@ -253,8 +253,8 @@ static async_deferred_awaitable *async_deferred_awaitable_object_create(async_de
 {
 	async_deferred_awaitable *awaitable;
 
-	awaitable = emalloc(sizeof(async_deferred));
-	ZEND_SECURE_ZERO(awaitable, sizeof(async_deferred));
+	awaitable = emalloc(sizeof(async_deferred_awaitable));
+	ZEND_SECURE_ZERO(awaitable, sizeof(async_deferred_awaitable));
 
 	zend_object_std_init(&awaitable->std, async_deferred_awaitable_ce);
 	awaitable->std.handlers = &async_deferred_awaitable_handlers;

--- a/src/deferred.c
+++ b/src/deferred.c
@@ -30,6 +30,59 @@ const zend_uchar ASYNC_DEFERRED_STATUS_FAILED = ASYNC_OP_FAILED;
 static zend_object_handlers async_deferred_handlers;
 static zend_object_handlers async_deferred_awaitable_handlers;
 
+
+#define ASYNC_DEFERRE_CLEANUP_CANCEL(defer) do { \
+	if (defer->context != NULL) { \
+			if (defer->cancel != NULL) { \
+				ASYNC_Q_DETACH(&defer->context->cancel->callbacks, defer->cancel); \
+				efree(defer->cancel); \
+				defer->cancel = NULL; \
+			} \
+			OBJ_RELEASE(&defer->context->std); \
+			defer->context = NULL; \
+		} \
+} while (0);
+
+
+static void cancel_defer(void *obj, zval* error, async_cancel_cb *cancel)
+{
+	async_deferred *defer;
+
+	zval args[2];
+	zval retval;
+
+	defer = (async_deferred *) obj;
+
+	ZEND_ASSERT(defer != NULL);
+
+	defer->cancel = NULL;
+
+	ZVAL_OBJ(&args[0], &defer->std);
+	GC_ADDREF(&defer->std);
+
+	ZVAL_COPY(&args[1], error);
+
+	cancel->fci.param_count = 2;
+	cancel->fci.params = args;
+	cancel->fci.retval = &retval;
+	cancel->fci.no_separation = 1;
+
+	zend_call_function(&cancel->fci, &cancel->fcc);
+
+	zval_ptr_dtor(&args[0]);
+	zval_ptr_dtor(&args[1]);
+	zval_ptr_dtor(&retval);
+
+	if (defer->context != NULL) {
+		OBJ_RELEASE(&defer->context->std);
+		defer->context = NULL;
+	}
+
+	zval_ptr_dtor(&cancel->fci.function_name);
+
+	ASYNC_CHECK_FATAL(UNEXPECTED(EG(exception)), "Must not throw an error from cancellation handler");
+}
+
 static void invoke_continuation_callback(zend_fcall_info *fci, zend_fcall_info_cache *fcc)
 {
 	async_task_scheduler *scheduler;
@@ -107,6 +160,8 @@ static void combine_continuation(void *obj, zval *data, zval *result, zend_bool 
 			ZVAL_OBJ(&combined->defer->result, EG(exception));
 			EG(exception) = NULL;
 
+			ASYNC_DEFERRE_CLEANUP_CANCEL(combined->defer);
+
 			async_awaitable_trigger_continuation(&combined->defer->continuation, &combined->defer->result, 0);
 		} else {
 			EG(exception) = NULL;
@@ -123,6 +178,8 @@ static void combine_continuation(void *obj, zval *data, zval *result, zend_bool 
 
 			ZVAL_OBJ(&combined->defer->result, EG(exception));
 			EG(exception) = NULL;
+
+			ASYNC_DEFERRE_CLEANUP_CANCEL(combined->defer);
 
 			async_awaitable_trigger_continuation(&combined->defer->continuation, &combined->defer->result, 0);
 		}
@@ -167,6 +224,8 @@ static void transform_continuation(void *obj, zval *data, zval *result, zend_boo
 
 	zval_ptr_dtor(&args[0]);
 	zval_ptr_dtor(&args[1]);
+
+	ASYNC_DEFERRE_CLEANUP_CANCEL(trans->defer);
 
 	if (UNEXPECTED(EG(exception))) {
 		trans->defer->status = ASYNC_DEFERRED_STATUS_FAILED;
@@ -288,7 +347,55 @@ static void async_deferred_object_destroy(zend_object *object)
 
 	zval_ptr_dtor(&defer->result);
 
+	ASYNC_DEFERRE_CLEANUP_CANCEL(defer);
+
 	zend_object_std_dtor(&defer->std);
+}
+
+ZEND_METHOD(Deferred, __construct)
+{
+	async_deferred *defer;
+	async_context *context;
+	async_cancel_cb *cancel;
+
+	zend_fcall_info fci;
+	zend_fcall_info_cache fcc;
+
+	ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 0, 1)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_FUNC_EX(fci, fcc, 1, 0)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (ZEND_NUM_ARGS() > 0) {
+		defer = (async_deferred *) Z_OBJ_P(getThis());
+		context = async_context_get();
+
+		do {
+			if (context->cancel != NULL) {
+				break;
+			}
+
+			context = context->parent;
+		} while (context != NULL);
+
+		if (context != NULL) {
+			cancel = emalloc(sizeof(async_cancel_cb));
+			ZEND_SECURE_ZERO(cancel, sizeof(async_cancel_cb));
+
+			cancel->object = defer;
+			cancel->func = cancel_defer;
+			cancel->fci = fci;
+			cancel->fcc = fcc;
+
+			Z_TRY_ADDREF_P(&fci.function_name);
+
+			defer->context = context;
+
+			GC_ADDREF(&context->std);
+
+			ASYNC_Q_ENQUEUE(&context->cancel->callbacks, cancel);
+		}
+	}
 }
 
 ZEND_METHOD(Deferred, __debugInfo)
@@ -358,6 +465,8 @@ ZEND_METHOD(Deferred, resolve)
 
 	defer->status = ASYNC_DEFERRED_STATUS_RESOLVED;
 
+	ASYNC_DEFERRE_CLEANUP_CANCEL(defer);
+
 	async_awaitable_trigger_continuation(&defer->continuation, &defer->result, 1);
 }
 
@@ -380,6 +489,8 @@ ZEND_METHOD(Deferred, fail)
 	ZVAL_COPY(&defer->result, error);
 
 	defer->status = ASYNC_DEFERRED_STATUS_FAILED;
+
+	ASYNC_DEFERRE_CLEANUP_CANCEL(defer);
 
 	async_awaitable_trigger_continuation(&defer->continuation, &defer->result, 0);
 }
@@ -626,6 +737,10 @@ ZEND_METHOD(Deferred, transform)
 	RETURN_ZVAL(&obj, 1, 1);
 }
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_deferred_ctor, 0, 0, 0)
+	ZEND_ARG_CALLABLE_INFO(0, cancel, 1)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO(arginfo_deferred_debug_info, 0)
 ZEND_END_ARG_INFO()
 
@@ -659,6 +774,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_deferred_transform, 0, 2, Concurr
 ZEND_END_ARG_INFO()
 
 static const zend_function_entry deferred_functions[] = {
+	ZEND_ME(Deferred, __construct, arginfo_deferred_ctor, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
 	ZEND_ME(Deferred, __debugInfo, arginfo_deferred_debug_info, ZEND_ACC_PUBLIC)
 	ZEND_ME(Deferred, awaitable, arginfo_deferred_awaitable, ZEND_ACC_PUBLIC)
 	ZEND_ME(Deferred, resolve, arginfo_deferred_resolve, ZEND_ACC_PUBLIC)

--- a/src/signal_watcher.c
+++ b/src/signal_watcher.c
@@ -96,7 +96,7 @@ static inline void suspend(async_signal_watcher *watcher, zval *return_value, ze
 		}
 	}
 
-	async_task_suspend(&watcher->observers, return_value, execute_data);
+	async_task_suspend(&watcher->observers, return_value, execute_data, 1);
 
 	if (context->background) {
 		watcher->unref_count--;

--- a/src/stream_watcher.c
+++ b/src/stream_watcher.c
@@ -154,7 +154,7 @@ static inline void suspend(async_stream_watcher *watcher, async_awaitable_queue 
 		}
 	}
 
-	async_task_suspend(q, return_value, execute_data);
+	async_task_suspend(q, return_value, execute_data, 1);
 
 	if (context->background) {
 		watcher->unref_count--;

--- a/src/task.c
+++ b/src/task.c
@@ -195,7 +195,6 @@ void async_task_suspend(async_awaitable_queue *q, zval *return_value, zend_execu
 	async_task_scheduler *scheduler;
 	async_awaitable_cb *cont;
 	async_context *context;
-	async_context *ctx;
 	async_cancel_cb *cancel;
 	async_task_suspended info;
 	size_t stack_page_size;
@@ -252,41 +251,27 @@ void async_task_suspend(async_awaitable_queue *q, zval *return_value, zend_execu
 
 	context = ASYNC_G(current_context);
 
-	if (cancellable) {
-		ctx = context;
+	if (cancellable && context->cancel != NULL) {
+		// Context is already cancelled.
+		if (Z_TYPE_P(&context->cancel->error) != IS_UNDEF) {
+			Z_ADDREF_P(&context->cancel->error);
 
-		do {
-			if (ctx->cancel != NULL) {
-				break;
-			}
+			execute_data->opline--;
+			zend_throw_exception_internal(&context->cancel->error);
+			execute_data->opline++;
 
-			ctx = ctx->parent;
-		} while (ctx != NULL);
-
-		if (ctx != NULL) {
-			// Context is already cancelled.
-			if (Z_TYPE_P(&ctx->cancel->error) != IS_UNDEF) {
-				Z_ADDREF_P(&ctx->cancel->error);
-
-				execute_data->opline--;
-				zend_throw_exception_internal(&ctx->cancel->error);
-				execute_data->opline++;
-
-				return;
-			}
-
-			cancel = emalloc(sizeof(async_cancel_cb));
-			ZEND_SECURE_ZERO(cancel, sizeof(async_cancel_cb));
-
-			cancel->object = task;
-			cancel->func = cancel_suspend;
-
-			ASYNC_Q_ENQUEUE(&ctx->cancel->callbacks, cancel);
-
-			GC_ADDREF(&ctx->std);
+			return;
 		}
-	} else {
-		ctx = NULL;
+
+		cancel = emalloc(sizeof(async_cancel_cb));
+		ZEND_SECURE_ZERO(cancel, sizeof(async_cancel_cb));
+
+		cancel->object = task;
+		cancel->func = cancel_suspend;
+
+		ASYNC_Q_ENQUEUE(&context->cancel->callbacks, cancel);
+
+		GC_ADDREF(&context->std);
 	}
 
 	task->suspended = async_awaitable_register_continuation(q, task, NULL, task_continuation);
@@ -301,12 +286,12 @@ void async_task_suspend(async_awaitable_queue *q, zval *return_value, zend_execu
 	ASYNC_G(current_context) = context;
 
 	// Dispose of cancel handler if task continued without cancellation.
-	if (ctx != NULL) {
+	if (cancellable && context->cancel != NULL) {
 		if (task->suspended == NULL) {
-			ASYNC_Q_DETACH(&ctx->cancel->callbacks, cancel);
+			ASYNC_Q_DETACH(&context->cancel->callbacks, cancel);
 		}
 
-		OBJ_RELEASE(&ctx->std);
+		OBJ_RELEASE(&context->std);
 	}
 
 	// Dispose of continuation if task continues before continuation fired.

--- a/src/task.c
+++ b/src/task.c
@@ -175,7 +175,7 @@ static void suspend_continuation(void *obj, zval *data, zval *result, zend_bool 
 	async_task_scheduler_stop_loop(suspended->scheduler);
 }
 
-static void cancel_suspend(void *obj, zval *error, async_cancel_cb *cb)
+static void cancel_suspend(void *obj, zval *error)
 {
 	async_task *task;
 

--- a/src/task.c
+++ b/src/task.c
@@ -175,7 +175,7 @@ static void suspend_continuation(void *obj, zval *data, zval *result, zend_bool 
 	async_task_scheduler_stop_loop(suspended->scheduler);
 }
 
-static void cancel_suspend(void *obj, zval *error)
+static void cancel_suspend(void *obj, zval *error, async_cancel_cb *cb)
 {
 	async_task *task;
 
@@ -186,6 +186,8 @@ static void cancel_suspend(void *obj, zval *error)
 	task->fiber.value = NULL;
 
 	async_task_scheduler_enqueue(task);
+
+	efree(cb);
 }
 
 void async_task_suspend(async_awaitable_queue *q, zval *return_value, zend_execute_data *execute_data, zend_bool cancellable)
@@ -289,6 +291,8 @@ void async_task_suspend(async_awaitable_queue *q, zval *return_value, zend_execu
 	if (cancellable && context->cancel != NULL) {
 		if (task->suspended == NULL) {
 			ASYNC_Q_DETACH(&context->cancel->callbacks, cancel);
+
+			efree(cancel);
 		}
 
 		OBJ_RELEASE(&context->std);

--- a/src/task.c
+++ b/src/task.c
@@ -132,6 +132,10 @@ static void task_continuation(void *obj, zval *data, zval *result, zend_bool suc
 
 	task->suspended = NULL;
 
+	if (task->operation != ASYNC_TASK_OPERATION_NONE) {
+		return;
+	}
+
 	if (result == NULL || task->fiber.status != ASYNC_FIBER_STATUS_SUSPENDED) {
 		task->fiber.status = ASYNC_FIBER_STATUS_FAILED;
 	} else if (success) {
@@ -180,6 +184,10 @@ static void cancel_suspend(void *obj, zval *error)
 	async_task *task;
 
 	task = (async_task *) obj;
+
+	if (task->operation != ASYNC_TASK_OPERATION_NONE) {
+		return;
+	}
 
 	ZVAL_COPY(&task->error, error);
 

--- a/src/task_scheduler.c
+++ b/src/task_scheduler.c
@@ -160,6 +160,7 @@ zend_bool async_task_scheduler_enqueue(async_task *task)
 	scheduler = task->scheduler;
 
 	ZEND_ASSERT(scheduler != NULL);
+	ZEND_ASSERT(task->operation == ASYNC_TASK_OPERATION_NONE);
 
 	if (task->fiber.status == ASYNC_FIBER_STATUS_INIT) {
 		task->operation = ASYNC_TASK_OPERATION_START;

--- a/src/timer.c
+++ b/src/timer.c
@@ -93,7 +93,7 @@ static inline void suspend(async_timer *timer, zval *return_value, zend_execute_
 		}
 	}
 
-	async_task_suspend(&timer->timeouts, return_value, execute_data);
+	async_task_suspend(&timer->timeouts, return_value, execute_data, 1);
 
 	if (context->background) {
 		timer->unref_count--;

--- a/tests/202-context-cancel-internal.phpt
+++ b/tests/202-context-cancel-internal.phpt
@@ -1,0 +1,54 @@
+--TEST--
+Context cancellation will spread to internally suspended operation.
+--SKIPIF--
+<?php
+if (!extension_loaded('task')) echo 'Test requires the task extension to be loaded';
+?>
+--FILE--
+<?php
+
+namespace Concurrent;
+
+$handler = new CancellationHandler(Context::current());
+
+Task::asyncWithContext($handler->context(), function () {
+    $signal = new SignalWatcher(SignalWatcher::SIGINT);
+    
+    var_dump('AWAIT SIGNAL');
+    
+    try {
+        $signal->awaitSignal();
+    } catch (\Throwable $e) {
+        var_dump($e->getMessage());
+    }
+    
+    try {
+        $signal->awaitSignal();
+    } catch (\Throwable $e) {
+        var_dump($e->getMessage());
+    }
+    
+    var_dump('DONE TASK');
+});
+
+var_dump('START TIMER');
+
+$timer = new Timer(25);
+$timer->awaitTimeout();
+
+var_dump('=> CANCEL');
+$handler->cancel();
+
+$timer->awaitTimeout();
+
+var_dump('DONE');
+
+?>
+--EXPECT--
+string(11) "START TIMER"
+string(12) "AWAIT SIGNAL"
+string(9) "=> CANCEL"
+string(26) "Context has been cancelled"
+string(26) "Context has been cancelled"
+string(9) "DONE TASK"
+string(4) "DONE"

--- a/tests/203-context-cancel-deferred.phpt
+++ b/tests/203-context-cancel-deferred.phpt
@@ -1,0 +1,44 @@
+--TEST--
+Context cancellation will trigger deferred cancellation callback.
+--SKIPIF--
+<?php
+if (!extension_loaded('task')) echo 'Test requires the task extension to be loaded';
+?>
+--FILE--
+<?php
+
+namespace Concurrent;
+
+$handler = new CancellationHandler();
+
+Task::asyncWithContext($handler->context(), function () {
+    $defer = new Deferred(function (Deferred $defer, \Throwable $e) {
+        var_dump($e->getMessage());
+        
+        $defer->resolve(777);
+    });
+    
+    var_dump('AWAIT DEFERRED');
+    var_dump(Task::await($defer->awaitable()));
+});
+
+var_dump('START TIMER');
+
+$timer = new Timer(100);
+$timer->awaitTimeout();
+
+var_dump('=> CANCEL!');
+$handler->cancel();
+
+$timer->awaitTimeout();
+
+var_dump('DONE');
+
+?>
+--EXPECT--
+string(11) "START TIMER"
+string(14) "AWAIT DEFERRED"
+string(10) "=> CANCEL!"
+string(26) "Context has been cancelled"
+int(777)
+string(4) "DONE"

--- a/tests/203-context-cancel-deferred.phpt
+++ b/tests/203-context-cancel-deferred.phpt
@@ -19,7 +19,16 @@ Task::asyncWithContext($handler->context(), function () {
     });
     
     var_dump('AWAIT DEFERRED');
+    var_dump(Context::current()->isCancelled());
+    
     var_dump(Task::await($defer->awaitable()));
+    var_dump(Context::current()->isCancelled());
+    
+    try {
+        Context::current()->throwIfCancelled();
+    } catch (\Throwable $e) {
+        var_dump($e->getMessage());
+    }
 });
 
 var_dump('START TIMER');
@@ -38,7 +47,10 @@ var_dump('DONE');
 --EXPECT--
 string(11) "START TIMER"
 string(14) "AWAIT DEFERRED"
+bool(false)
 string(10) "=> CANCEL!"
 string(26) "Context has been cancelled"
 int(777)
+bool(true)
+string(26) "Context has been cancelled"
 string(4) "DONE"

--- a/tests/204-context-cancel-chain.phpt
+++ b/tests/204-context-cancel-chain.phpt
@@ -1,0 +1,50 @@
+--TEST--
+Context cancellation is chained with parent cancellation.
+--SKIPIF--
+<?php
+if (!extension_loaded('task')) echo 'Test requires the task extension to be loaded';
+?>
+--FILE--
+<?php
+
+namespace Concurrent;
+
+$h1 = new CancellationHandler();
+$h2 = new CancellationHandler($h1->context());
+
+Task::asyncWithContext($h2->context(), function () {
+    $defer = new Deferred(function (Deferred $defer, \Throwable $e) {
+        var_dump('CANCEL OP');
+        
+        $defer->fail($e);
+    });
+    
+    var_dump('AWAIT DEFER');
+    
+    try {
+        Task::await($defer->awaitable());
+    } catch (\Throwable $e) {
+        var_dump($e->getMessage());
+    }
+});
+
+var_dump('START TIMER');
+
+$timer = new Timer(50);
+$timer->awaitTimeout();
+
+var_dump('=> CANCEL!');
+$h1->cancel();
+
+$timer->awaitTimeout();
+
+var_dump('DONE');
+
+?>
+--EXPECT--
+string(11) "START TIMER"
+string(11) "AWAIT DEFER"
+string(10) "=> CANCEL!"
+string(9) "CANCEL OP"
+string(26) "Context has been cancelled"
+string(4) "DONE"

--- a/tests/205-context-cancel-nested.phpt
+++ b/tests/205-context-cancel-nested.phpt
@@ -1,0 +1,65 @@
+--TEST--
+Context cancellation of nested context does not affect unrelated context.
+--SKIPIF--
+<?php
+if (!extension_loaded('task')) echo 'Test requires the task extension to be loaded';
+?>
+--FILE--
+<?php
+
+namespace Concurrent;
+
+$h1 = new CancellationHandler();
+$h2 = new CancellationHandler($h1->context());
+$h3 = new CancellationHandler($h1->context());
+
+Task::asyncWithContext($h2->context(), function () {
+    $defer = new Deferred(function (Deferred $defer, \Throwable $e) {
+        var_dump('CANCEL OP');
+        
+        $defer->fail($e);
+    });
+    
+    var_dump('AWAIT DEFER');
+    
+    try {
+        Task::await($defer->awaitable());
+    } catch (\Throwable $e) {
+        var_dump($e->getMessage());
+    }
+});
+
+Task::asyncWithContext($h3->context(), function () {
+    var_dump('START UNRELATED');
+    
+    (new Timer(200))->awaitTimeout();
+    
+    Context::current()->throwIfCancelled();
+    
+    var_dump(Context::current()->isCancelled());
+    var_dump('DONE UNRELATED');
+});
+
+var_dump('START TIMER');
+
+$timer = new Timer(50);
+$timer->awaitTimeout();
+
+var_dump('=> CANCEL!');
+$h2->cancel();
+
+$timer->awaitTimeout();
+
+var_dump('DONE');
+
+?>
+--EXPECT--
+string(11) "START TIMER"
+string(11) "AWAIT DEFER"
+string(15) "START UNRELATED"
+string(10) "=> CANCEL!"
+string(9) "CANCEL OP"
+string(26) "Context has been cancelled"
+string(4) "DONE"
+bool(false)
+string(14) "DONE UNRELATED"

--- a/tests/206-context-cancel-timeout.phpt
+++ b/tests/206-context-cancel-timeout.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Context cancellation can be triggered using an internal timer.
+--SKIPIF--
+<?php
+if (!extension_loaded('task')) echo 'Test requires the task extension to be loaded';
+?>
+--FILE--
+<?php
+
+namespace Concurrent;
+
+Task::asyncWithContext(Context::current()->withTimeout(100), function () {
+    (new Timer(50))->awaitTimeout();
+
+    var_dump('DONE 1');
+});
+
+Task::asyncWithContext(Context::current()->withTimeout(100), function () {
+    try {
+        (new Timer(200))->awaitTimeout();
+    } catch (\Throwable $e) {
+        var_dump($e->getMessage());
+    }
+
+    var_dump('DONE 2');
+});
+
+var_dump('START');
+
+?>
+--EXPECT--
+string(5) "START"
+string(6) "DONE 1"
+string(17) "Context timed out"
+string(6) "DONE 2"

--- a/tests/208-context-cancel-shield.phpt
+++ b/tests/208-context-cancel-shield.phpt
@@ -1,0 +1,41 @@
+--TEST--
+Context can be shielded from cancellation.
+--SKIPIF--
+<?php
+if (!extension_loaded('task')) echo 'Test requires the task extension to be loaded';
+?>
+--FILE--
+<?php
+
+namespace Concurrent;
+
+$handler = new CancellationHandler();
+
+Task::asyncWithContext($handler->context(), function () {
+    try {
+        (new Timer(50))->awaitTimeout();
+    } catch (\Throwable $e) {
+        var_dump($e->getMessage());
+    }
+
+    var_dump('DONE 1');
+});
+
+Task::asyncWithContext($handler->context()->shield(), function () {
+    (new Timer(50))->awaitTimeout();
+
+    var_dump('DONE 2');
+});
+
+var_dump('START');
+
+(new Timer(10))->awaitTimeout();
+
+$handler->cancel();
+
+?>
+--EXPECT--
+string(5) "START"
+string(26) "Context has been cancelled"
+string(6) "DONE 1"
+string(6) "DONE 2"


### PR DESCRIPTION
This PR adds contextual cancellation support for all async operations. It adds a callback-based cancellation handler to `Deferred` to allow for userland cancellation handling. Async operations related to the event loop  (`Timer`, `StreamWatcher`, `SignalWatcher`) are also cancellable. The basic ideas are outlined in #13, the implementation is a little different in that it avoids the tuple-return methods. The proposed `CancellationToken` API has been moved to the `Context` class. The `CancellationHandler` has ben changed to provide a derived context and a means of cancelling it.